### PR TITLE
[fix] Fixed broken geographic map

### DIFF
--- a/src/js/netjsongraph.render.js
+++ b/src/js/netjsongraph.render.js
@@ -1,4 +1,5 @@
 import * as echarts from "echarts/lib/echarts";
+import {ScatterChart} from "echarts/charts";
 import "echarts/lib/chart/graph";
 import "echarts/lib/chart/effectScatter";
 import "echarts/lib/chart/lines";
@@ -78,6 +79,7 @@ class NetJSONGraphRender {
       configs.echartsOption,
     );
 
+    echarts.use([ScatterChart]);
     echartsLayer.setOption(self.utils.deepMergeObj(commonOption, customOption));
     echartsLayer.on(
       "click",


### PR DESCRIPTION
Geographic map is now fixed, earlier broken as a result of `echarts` dependency upgrade.
<img width="1059" alt="Screenshot 2024-02-28 at 4 35 56 PM" src="https://github.com/openwisp/netjsongraph.js/assets/120790871/ccbc976c-902c-41bb-8e95-9c524b04e2f1">

#244