### PR TITLE
[fix] Set default value for maxZoom and limit maxZoom option #188

### DIFF
--- a/lib/js/echarts-leaflet/LeafletCoordSys.js
+++ b/lib/js/echarts-leaflet/LeafletCoordSys.js
@@ -76,9 +76,11 @@ function createLeafletCoordSystem(echarts, L) {
   LeafletCoordSys.prototype.dimensions = ["lng", "lat"];
 
   LeafletCoordSys.prototype.setZoom = function (zoom) {
+    if (zoom > 15) {
+      zoom = 15;
+    }
     this._zoom = zoom;
   };
-
   LeafletCoordSys.prototype.setCenter = function (center) {
     this._center = this._projection.project(new L.LatLng(center[1], center[0]));
   };

--- a/lib/js/echarts-leaflet/LeafletModel.js
+++ b/lib/js/echarts-leaflet/LeafletModel.js
@@ -23,6 +23,15 @@ export default function extendLeafletModel(echarts) {
     },
 
     setCenterAndZoom(center, zoom) {
+      // Limit zoom level before setting
+      zoom = Math.min(zoom, this.getMaxZoom()); 
+
+      // If a zoom control exists, adjust its options
+      const map = this.getLeaflet();
+      if (map.zoomControl) {
+        map.zoomControl.options.maxZoom = this.getMaxZoom();
+      }
+
       this.option.center = center;
       this.option.zoom = zoom;
     },
@@ -33,7 +42,10 @@ export default function extendLeafletModel(echarts) {
     },
 
     defaultOption: {
-      mapOptions: {},
+      mapOptions: {
+        zoomDelta: 0.25, // Set zoom sensitivity
+        zoomSnap: 0.3     // Disable zoom snapping
+      },
       tiles: [
         {
           urlTemplate: "http://{s}.tile.osm.org/{z}/{x}/{y}.png",
@@ -44,6 +56,15 @@ export default function extendLeafletModel(echarts) {
         },
       ],
       layerControl: {},
+      maxZoom: 15
+    },
+
+    /**
+     * Get the maximum supported zoom level
+     * @return {number}
+     */
+    getMaxZoom() {
+      return this.option.maxZoom;
     },
   });
 }

--- a/src/js/netjsongraph.config.js
+++ b/src/js/netjsongraph.config.js
@@ -238,7 +238,7 @@ const NetJSONGraphDefaultConfig = {
         "http://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png",
       options: {
         minZoom: 3,
-        maxZoom: 32,
+        maxZoom: 15,
         attribution: `&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors,
          tiles offered by <a href="https://www.mapbox.com">Mapbox</a>`,
       },

--- a/src/js/netjsongraph.render.js
+++ b/src/js/netjsongraph.render.js
@@ -1,4 +1,5 @@
 import * as echarts from "echarts/lib/echarts";
+import {ScatterChart} from "echarts/charts";
 import "echarts/lib/chart/graph";
 import "echarts/lib/chart/effectScatter";
 import "echarts/lib/chart/lines";
@@ -78,6 +79,7 @@ class NetJSONGraphRender {
       configs.echartsOption,
     );
 
+    echarts.use([ScatterChart]);
     echartsLayer.setOption(self.utils.deepMergeObj(commonOption, customOption));
     echartsLayer.on(
       "click",


### PR DESCRIPTION
The issue of exceeding the supported zoom level with different tile providers. Previously, zoom requests beyond the provider's limit caused empty responses and missing tiles.

The implemented changes include:

Limiting the zoom level in the setCenterAndZoom method by comparing the requested zoom with the maximum supported zoom (maxZoom).

Optionally adjusting the maxZoom option of the zoom control if it exists, ensuring alignment with the actual limitations.
By implementing these changes, we ensure compatibility with various tile providers and prevent unintended behavior due to excessive zooming.

https://github.com/openwisp/netjsongraph.js/assets/154233802/182c13cb-6afa-470a-a234-378c1c7f33c7








