### PR TITLE
[fix] Reduce max zoom level to prevent unintended behavior due to exc…

### DIFF
--- a/lib/js/echarts-leaflet/LeafletCoordSys.js
+++ b/lib/js/echarts-leaflet/LeafletCoordSys.js
@@ -7,8 +7,8 @@
  *
  * @return {function} LeafletCoordSys
  */
-function createLeafletCoordSystem(echarts, L) {
-  const {util, graphic, matrix} = echarts;
+function createLeafletCoordSystem(echarts, L, defaultconfig = {}) {
+  const { util, graphic, matrix } = echarts;
   const CustomOverlay = L.Layer.extend({
     initialize(container) {
       this._container = container;
@@ -53,10 +53,12 @@ function createLeafletCoordSystem(echarts, L) {
     this._mapOffset = [0, 0];
     this._api = api;
     this._projection = L.Projection.Mercator;
+    const maxZoom = defaultconfig.maxZoom || 15; // Set default max zoom level
+    this._maxZoom = maxZoom;
   }
 
   function doConvert(methodName, ecModel, finder, value) {
-    const {leafletModel, seriesModel} = finder;
+    const { leafletModel, seriesModel } = finder;
 
     /* eslint-disable */
     const coordSys = leafletModel
@@ -65,7 +67,7 @@ function createLeafletCoordSystem(echarts, L) {
       ? seriesModel.coordinateSystem || // For map.
         (seriesModel.getReferringComponents("leaflet")[0] || {})
           .coordinateSystem
-      : null;
+   : null;
     return coordSys === this ? coordSys[methodName](value) : null;
     /* eslint-enable */
   }
@@ -76,6 +78,10 @@ function createLeafletCoordSystem(echarts, L) {
   LeafletCoordSys.prototype.dimensions = ["lng", "lat"];
 
   LeafletCoordSys.prototype.setZoom = function (zoom) {
+    const maxZoom = this._maxZoom;
+    if (zoom > maxZoom) {
+      zoom = maxZoom;
+    }
     this._zoom = zoom;
   };
 
@@ -198,7 +204,7 @@ function createLeafletCoordSystem(echarts, L) {
       leafletCoordSys = new LeafletCoordSys(map, api);
       leafletList.push(leafletCoordSys);
       leafletCoordSys.setMapOffset(leafletModel.__mapOffset || [0, 0]);
-      const {center, zoom} = leafletModel.get("mapOptions");
+      const { center, zoom } = leafletModel.get("mapOptions");
       if (center && zoom) {
         leafletCoordSys.setZoom(zoom);
         leafletCoordSys.setCenter(center);

--- a/lib/js/echarts-leaflet/LeafletModel.js
+++ b/lib/js/echarts-leaflet/LeafletModel.js
@@ -23,6 +23,7 @@ export default function extendLeafletModel(echarts) {
     },
 
     setCenterAndZoom(center, zoom) {
+    
       this.option.center = center;
       this.option.zoom = zoom;
     },
@@ -33,7 +34,10 @@ export default function extendLeafletModel(echarts) {
     },
 
     defaultOption: {
-      mapOptions: {},
+      mapOptions: {
+        zoomDelta: 0.25, // Set zoom sensitivity
+        zoomSnap: 0.19     // Disable zoom snapping
+      },
       tiles: [
         {
           urlTemplate: "http://{s}.tile.osm.org/{z}/{x}/{y}.png",
@@ -44,6 +48,7 @@ export default function extendLeafletModel(echarts) {
         },
       ],
       layerControl: {},
+      
     },
   });
 }

--- a/lib/js/echarts-leaflet/LeafletModel.js
+++ b/lib/js/echarts-leaflet/LeafletModel.js
@@ -23,6 +23,14 @@ export default function extendLeafletModel(echarts) {
     },
 
     setCenterAndZoom(center, zoom) {
+       // Limit zoom level before setting
+       const maxZoom = this.option.mapOptions.maxZoom || this.getMaxZoom();
+       zoom = Math.min(zoom, maxZoom);
+       // If a zoom control exists, adjust its options
+       const map = this.getLeaflet();
+       if (map.zoomControl) {
+         map.zoomControl.options.maxZoom = maxZoom;
+       }
     
       this.option.center = center;
       this.option.zoom = zoom;
@@ -36,7 +44,8 @@ export default function extendLeafletModel(echarts) {
     defaultOption: {
       mapOptions: {
         zoomDelta: 0.25, // Set zoom sensitivity
-        zoomSnap: 0.19     // Disable zoom snapping
+        zoomSnap: 0.19,    // Disable zoom snapping
+        maxZoom: 15 
       },
       tiles: [
         {
@@ -48,7 +57,13 @@ export default function extendLeafletModel(echarts) {
         },
       ],
       layerControl: {},
-      
+    },
+    /**
+     * Get the maximum supported zoom level
+     * @return {number}
+     */
+    getMaxZoom() {
+      return this.option.maxZoom;
     },
   });
 }

--- a/src/js/netjsongraph.config.js
+++ b/src/js/netjsongraph.config.js
@@ -238,7 +238,7 @@ const NetJSONGraphDefaultConfig = {
         "http://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png",
       options: {
         minZoom: 3,
-        maxZoom: 32,
+        maxZoom: 15,
         attribution: `&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors,
          tiles offered by <a href="https://www.mapbox.com">Mapbox</a>`,
       },


### PR DESCRIPTION
Adjust the max zoom level to mitigate excessive zooming behaviour. Set zoom sensitivity and max zoom value from 32 to 15.


https://github.com/openwisp/netjsongraph.js/assets/154233802/c59a9668-3449-48d6-a209-27b5e1fb79a1





