### PR TITLE
[fix] Remove global CSS rules to avoid conflicts #303  Refactored CSS to prevent global styling conflicts with downstream projects. Fixes #303

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,8 @@ updates:
       interval: "monthly"
     open-pull-requests-limit: 10
     versioning-strategy: increase-if-necessary
+    commit-message:
+      prefix: "[deps] "
   - package-ecosystem: "github-actions" # Check for GitHub Actions updates
     directory: "/" # The root directory where the Ansible role is located
     schedule:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,10 +72,11 @@ jobs:
       - name: Wait for server to be ready
         run: npx wait-on http://localhost:8080
 
-      - name: Setup Chrome and ChromeDriver
+      - name: Set up Chrome
         uses: browser-actions/setup-chrome@v1
-        with:
-          install-chromedriver: true
+
+      - name: Set up ChromeDriver
+        uses: nanasess/setup-chromedriver@v2
 
       - name: Check chrome and chromedriver version
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,7 +94,7 @@ jobs:
 
   build-and-deploy:
     name: Build and Deploy
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     if: ${{ github.event_name=='push' }}
     env:
       MAPBOX_URL_TEMPLATE: ${{ secrets.MAPBOX_URL_TEMPLATE }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,8 +84,12 @@ jobs:
           chromedriver --version
           which chromedriver
 
-      - name: Tests
-        run: yarn coverage
+      - name: Unit tests
+        run: yarn coverage --testPathIgnorePatterns=test/netjsongraph.browser.test.js
+  
+      - name: Browser tests
+        # Test timeout set to 30 seconds in CI since it runs slower
+        run: yarn test --runInBand --testTimeout=30000 test/netjsongraph.browser.test.js
 
       - name: Coveralls
         uses: coverallsapp/github-action@master

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,14 +30,13 @@ jobs:
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
           restore-keys: ${{ runner.os }}-yarn-
 
-      - name: Set up Python 3.7
+      - name: Set up Python
         uses: actions/setup-python@v5
-        with:
-          python-version: 3.7
 
       - name: Installing dependencies
         run: |
           yarn install
+          python --version
           pip install openwisp-utils[qa]
 
       - name: QA checks

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,6 +74,8 @@ jobs:
 
       - name: Setup Chrome and ChromeDriver
         uses: browser-actions/setup-chrome@v1
+        with:
+          install-chromedriver: true
 
       - name: Check chrome and chromedriver version
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,22 @@ jobs:
         run: |
           yarn install
 
+      - name: Running Server
+        run: yarn start &
+
+      - name: Wait for server to be ready
+        run: npx wait-on http://localhost:8080
+
+      - name: Setup Chrome and ChromeDriver
+        uses: browser-actions/setup-chrome@v1
+
+      - name: Check chrome and chromedriver version
+        run: |
+          chrome --version
+          which chrome
+          chromedriver --version
+          which chromedriver
+
       - name: Tests
         run: yarn coverage
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   qa-checks:
     name: QA-Checks
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v4
@@ -45,7 +45,7 @@ jobs:
 
   build:
     name: Tests and Coverage
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -21,6 +21,23 @@ yarn install
 yarn start
 ```
 
+### Run Tests
+
+```
+yarn start &  # or alternatively run this in a separate terminal
+yarn test
+```
+
+To run a specific test suite:
+
+```
+yarn test test/netjsongraph.browser.test.js
+```
+
+The test suite includes browser tests.
+
+Ensure that ChromeDriver is installed.
+
 ### Arguments
 
 netjsongraph.js accepts two arguments.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # netjsongraph.js
 
-[![CI](https://github.com/openwisp/netjsongraph.js/workflows/netjsongraph.js%20CI%20BUILD/badge.svg?branch=master)](<[https://travis-ci.org/openwisp/netjsongraph.js](https://github.com/openwisp/netjsongraph.js/actions/workflows/ci.yml)>)
-[![Coverage Status](https://coveralls.io/repos/github/openwisp/netjsongraph.js/badge.svg?branch=gsoc2019)](https://coveralls.io/github/openwisp/netjsongraph.js?branch=gsoc2019)
+[![netjsongraph.js CI BUILD](https://github.com/openwisp/netjsongraph.js/actions/workflows/ci.yml/badge.svg)](https://github.com/openwisp/netjsongraph.js/actions/workflows/ci.yml)
+[![Coverage Status](https://coveralls.io/repos/github/openwisp/netjsongraph.js/badge.svg?branch=master)](https://coveralls.io/github/openwisp/netjsongraph.js?branch=master)
 ![Language](https://img.shields.io/badge/language-javascript-orange.svg)
 
 ![img](/docs/graph.png)

--- a/README.md
+++ b/README.md
@@ -23,8 +23,18 @@ yarn start
 
 ### Run Tests
 
+The test suite includes browser tests, so **ensure that ChromeDriver is installed** before running them.
+
+Start the development server first:
+
 ```
-yarn start &  # or alternatively run this in a separate terminal
+# Required for Selenium browser tests
+yarn start
+```
+
+Then, in a separate terminal, run:
+
+```
 yarn test
 ```
 
@@ -33,10 +43,6 @@ To run a specific test suite:
 ```
 yarn test test/netjsongraph.browser.test.js
 ```
-
-The test suite includes browser tests.
-
-Ensure that ChromeDriver is installed.
 
 ### Arguments
 

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "dotenv-webpack": "^8.0.1",
     "eslint": "^8.57.0",
     "eslint-config-airbnb": "^19.0.4",
-    "eslint-config-prettier": "^9.1.0",
+    "eslint-config-prettier": "^10.0.1",
     "eslint-plugin-import": "^2.29.1",
     "eslint-plugin-jsx-a11y": "^6.8.0",
     "eslint-plugin-react": "^7.33.2",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "@testing-library/jest-dom": "^6.4.2",
     "@types/jest": "^29.5.12",
     "acorn": "^8.11.3",
-    "copy-webpack-plugin": "^12.0.2",
+    "copy-webpack-plugin": "^13.0.0",
     "coveralls": "^3.1.1",
     "css-loader": "^7.1.2",
     "dotenv-webpack": "^8.0.1",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,10 @@
     "globalSetup": "./jest.global-setup.js",
     "moduleNameMapper": {
       "\\.(css)$": "identity-obj-proxy"
-    }
+    },
+    "coveragePathIgnorePatterns": [
+      "test/"
+    ]
   },
   "repository": "https://github.com/netjson/netjsongraph.js.git",
   "author": "Federico Capoano <f.capoano@openwisp.io> (https://openwisp.io)",
@@ -68,6 +71,7 @@
     "jest-environment-jsdom": "^29.7.0",
     "lint-staged": "^15.2.2",
     "prettier": "^3.2.5",
+    "selenium-webdriver": "^4.29.0",
     "style-loader": "^4.0.0",
     "terser-webpack-plugin": "^5.3.10",
     "webpack": "^5.90.3",
@@ -75,11 +79,11 @@
     "webpack-dev-server": "^5.0.2"
   },
   "dependencies": {
-    "echarts": "^5.3.3",
-    "echarts-gl": "^2.0.8",
+    "echarts": "^5.6.0",
+    "echarts-gl": "^2.0.9",
     "kdbush": "^4.0.2",
     "leaflet": "^1.8.0",
     "leaflet.markercluster": "^1.5.3",
-    "zrender": "^5.3.2"
+    "zrender": "^5.6.1"
   }
 }

--- a/public/assets/css/example.css
+++ b/public/assets/css/example.css
@@ -1,0 +1,9 @@
+@font-face {
+  font-family: "iconfont";
+  src: url("../assets/fonts/iconfont.eot");
+  src: url("../assets/fonts/iconfont.eot?#iefix") format("embedded-opentype"),
+       url("../assets/fonts/iconfont.woff2") format("woff2"),
+       url("../assets/fonts/iconfont.woff") format("woff"),
+       url("../assets/fonts/iconfont.ttf") format("truetype"),
+       url("../assets/fonts/iconfont.svg#iconfont") format("svg");
+}

--- a/public/example_templates/netjson-clustering.html
+++ b/public/example_templates/netjson-clustering.html
@@ -21,19 +21,6 @@
         width: 100%;
       }
 
-      .netjsongraph-container {
-        position: absolute;
-        top: 0;
-        left: 0;
-        width: 100%;
-        height: 100%;
-      }
-
-      #graphChartContainer {
-        width: 100%;
-        height: 100%;
-      }
-
       #legend h4 {
         margin: 10px 0;
         text-align: center;

--- a/public/example_templates/netjson-clustering.html
+++ b/public/example_templates/netjson-clustering.html
@@ -14,6 +14,26 @@
     <link href="../lib/css/netjsongraph-theme.css" rel="stylesheet" />
     <link href="../lib/css/netjsongraph.css" rel="stylesheet" />
     <style type="text/css">
+      html, body {
+        margin: 0;
+        padding: 0;
+        height: 100%;
+        width: 100%;
+      }
+
+      .netjsongraph-container {
+        position: absolute;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+      }
+
+      #graphChartContainer {
+        width: 100%;
+        height: 100%;
+      }
+
       #legend h4 {
         margin: 10px 0;
         text-align: center;
@@ -68,9 +88,13 @@
     </style>
   </head>
   <body>
+    <div class="netjsongraph-container">
+     <div id="graphChartContainer"></div>
+    </div>
     <script type="text/javascript">
       const map = new NetJSONGraph("../assets/data/netjsonmap.json", {
         render: "map",
+        container: "#graphChartContainer",
         clustering: true,
         clusteringThreshold: 50,
         // set map initial state.

--- a/public/example_templates/netjson-clustering.html
+++ b/public/example_templates/netjson-clustering.html
@@ -13,14 +13,8 @@
     <!-- theme can be easily customized via css -->
     <link href="../lib/css/netjsongraph-theme.css" rel="stylesheet" />
     <link href="../lib/css/netjsongraph.css" rel="stylesheet" />
+    <link href="../assets/css/examples.css" rel="stylesheet" />
     <style type="text/css">
-      html, body {
-        margin: 0;
-        padding: 0;
-        height: 100%;
-        width: 100%;
-      }
-
       #legend h4 {
         margin: 10px 0;
         text-align: center;
@@ -75,13 +69,14 @@
     </style>
   </head>
   <body>
-    <div class="netjsongraph-container">
-     <div id="graphChartContainer"></div>
-    </div>
+    <!-- Replace with the simplified container structure -->
+    <div id="njg"></div>
+    
     <script type="text/javascript">
       const map = new NetJSONGraph("../assets/data/netjsonmap.json", {
         render: "map",
-        container: "#graphChartContainer",
+        // Update to use the new container ID
+        el: "#njg",
         clustering: true,
         clusteringThreshold: 50,
         // set map initial state.

--- a/public/example_templates/netjson-dateParse.html
+++ b/public/example_templates/netjson-dateParse.html
@@ -7,19 +7,12 @@
     <!-- theme can be easily customized via css -->
     <link href="../lib/css/netjsongraph-theme.css" rel="stylesheet" />
     <link href="../lib/css/netjsongraph.css" rel="stylesheet" />
+    <link href="../assets/css/examples.css" rel="stylesheet" />
     <style>
-       html, body {
-        margin: 0;
-        padding: 0;
-        height: 100%;
-        width: 100%;
-      }
-
       .njg-date {
         height: fit-content;
         text-align: center;
       }
-
       @media only screen and (max-width: 850px) {
         .njg-date {
           width: 100vw;
@@ -28,21 +21,22 @@
       }
     </style>
   </head>
-
   <body>
-    <div class="netjsongraph-container">
-     <div id="graphChartContainer"></div>
-   </div>
-
+    <!-- Add the container structure as recommended -->
+    <div id="njg">
+      <!-- Graph will be rendered here -->
+    </div>
+    
     <script type="text/javascript">
       /*
         The demo is used to show the use of the `dataParse` function.
         You can set the node or link property value `time`, we will call this function to parse the string in the element details defaultly.
         Of course you can also call directly.
-    */
+      */
       // `graph` render defaultly.
       const graph = new NetJSONGraph("../assets/data/netjsonmap.json", {
-        container: "#graphChartContainer",
+        // Update the container target to use the new structure
+        el: "#njg",
         // Convert to internal json format，add `time` field.
         prepareData: (data) => {
           data.nodes.map((node) => {
@@ -58,9 +52,7 @@
           });
         },
       });
-
       graph.render();
-
       (function addDateParse(_this) {
         const dateNode = document.createElement("span"),
           // Try to call the function directly.
@@ -70,7 +62,6 @@
             parseRegular:
               /^([1-9]\d{3})-(\d{1,2})-(\d{1,2})T(\d{1,2}):(\d{1,2}):(\d{1,2})(?:\.(\d{1,3}))?Z$/,
           });
-
         dateNode.setAttribute("title", dateResult);
         dateNode.setAttribute("class", "njg-date");
         dateNode.innerHTML = "Incoming Time: " + dateResult;

--- a/public/example_templates/netjson-dateParse.html
+++ b/public/example_templates/netjson-dateParse.html
@@ -15,19 +15,6 @@
         width: 100%;
       }
 
-      .netjsongraph-container {
-        position: absolute;
-        top: 0;
-        left: 0;
-        width: 100%;
-        height: 100%;
-      }
-
-      #graphChartContainer {
-        width: 100%;
-        height: 100%;
-      }
-
       .njg-date {
         height: fit-content;
         text-align: center;

--- a/public/example_templates/netjson-dateParse.html
+++ b/public/example_templates/netjson-dateParse.html
@@ -8,6 +8,26 @@
     <link href="../lib/css/netjsongraph-theme.css" rel="stylesheet" />
     <link href="../lib/css/netjsongraph.css" rel="stylesheet" />
     <style>
+       html, body {
+        margin: 0;
+        padding: 0;
+        height: 100%;
+        width: 100%;
+      }
+
+      .netjsongraph-container {
+        position: absolute;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+      }
+
+      #graphChartContainer {
+        width: 100%;
+        height: 100%;
+      }
+
       .njg-date {
         height: fit-content;
         text-align: center;
@@ -23,6 +43,10 @@
   </head>
 
   <body>
+    <div class="netjsongraph-container">
+     <div id="graphChartContainer"></div>
+   </div>
+
     <script type="text/javascript">
       /*
         The demo is used to show the use of the `dataParse` function.
@@ -31,6 +55,7 @@
     */
       // `graph` render defaultly.
       const graph = new NetJSONGraph("../assets/data/netjsonmap.json", {
+        container: "#graphChartContainer",
         // Convert to internal json format，add `time` field.
         prepareData: (data) => {
           data.nodes.map((node) => {

--- a/public/example_templates/netjson-multipleInterfaces.html
+++ b/public/example_templates/netjson-multipleInterfaces.html
@@ -14,19 +14,6 @@
         height: 100%;
         width: 100%;
       }
-
-      .netjsongraph-container {
-        position: absolute;
-        top: 0;
-        left: 0;
-        width: 100%;
-        height: 100%;
-      }
-
-      #graphChartContainer {
-        width: 100%;
-        height: 100%;
-      }
     </style>
   </head>
   <body>

--- a/public/example_templates/netjson-multipleInterfaces.html
+++ b/public/example_templates/netjson-multipleInterfaces.html
@@ -7,8 +7,32 @@
     <!-- theme can be easily customized via css -->
     <link href="../lib/css/netjsongraph-theme.css" rel="stylesheet" />
     <link href="../lib/css/netjsongraph.css" rel="stylesheet" />
+    <style>
+      html, body {
+        margin: 0;
+        padding: 0;
+        height: 100%;
+        width: 100%;
+      }
+
+      .netjsongraph-container {
+        position: absolute;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+      }
+
+      #graphChartContainer {
+        width: 100%;
+        height: 100%;
+      }
+    </style>
   </head>
   <body>
+     <div class="netjsongraph-container">
+     <div id="graphChartContainer"></div>
+   </div>
     <script type="text/javascript">
       /*
             The demo is used to show how to deal with the `multiple interfaces` in the NetJSON data.
@@ -20,6 +44,7 @@
       const graph = new NetJSONGraph(
         "../assets/data/netjson-multipleInterfaces.json",
         {
+          container: "#graphChartContainer",
           // Asynchronous processing of incoming data formats using WebWorker file.
           dealDataByWorker: "../lib/js/netjsonWorker.js",
         },

--- a/public/example_templates/netjson-multipleInterfaces.html
+++ b/public/example_templates/netjson-multipleInterfaces.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
     <title>netjsongraph.js: basic example</title>
@@ -7,32 +7,33 @@
     <!-- theme can be easily customized via css -->
     <link href="../lib/css/netjsongraph-theme.css" rel="stylesheet" />
     <link href="../lib/css/netjsongraph.css" rel="stylesheet" />
-    <style>
-      html, body {
-        margin: 0;
-        padding: 0;
-        height: 100%;
-        width: 100%;
-      }
-    </style>
+    <link href="../assets/css/examples.css" rel="stylesheet" />
   </head>
   <body>
-     <div class="netjsongraph-container">
-     <div id="graphChartContainer"></div>
-   </div>
+    <div id="njg">
+      <!-- This is the main container  -->
+      <div class="njg-relativePosition"></div>
+
+      <!-- Loading container  -->
+      <div id="loadingContainer">
+        <div class="loadingElement">
+          <div class="loadingSprite"></div>
+          <div class="loadingTip">Loading...</div>
+        </div>
+      </div>
+    </div>
+
     <script type="text/javascript">
       /*
-            The demo is used to show how to deal with the `multiple interfaces` in the NetJSON data.
-            We provide a work file to process the data before rendering. 
-            This file provides functions to remove dirty data, deduplicate, handle multiple interfaces, add node links, add flatNodes and so on.
-            You can also define related files yourself.
-        */
-      // `graph` render defaultly.
+        The demo is used to show how to deal with the `multiple interfaces` in the NetJSON data.
+        We provide a work file to process the data before rendering. 
+        This file provides functions to remove dirty data, deduplicate, handle multiple interfaces, 
+        add node links, add flatNodes and so on.
+      */
       const graph = new NetJSONGraph(
         "../assets/data/netjson-multipleInterfaces.json",
         {
-          container: "#graphChartContainer",
-          // Asynchronous processing of incoming data formats using WebWorker file.
+          el: "#njg",
           dealDataByWorker: "../lib/js/netjsonWorker.js",
         },
       );

--- a/public/example_templates/netjson-searchElements.html
+++ b/public/example_templates/netjson-searchElements.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
     <title>netjsongraph.js: basic example</title>
@@ -7,14 +7,8 @@
     <!-- theme can be easily customized via css -->
     <link href="../lib/css/netjsongraph-theme.css" rel="stylesheet" />
     <link href="../lib/css/netjsongraph.css" rel="stylesheet" />
+    <link href="../assets/css/examples.css" rel="stylesheet" />
     <style>
-       html, body {
-        margin: 0;
-        padding: 0;
-        height: 100%;
-        width: 100%;
-      }
-
       .njg-searchBtn {
         border: none;
         border-radius: 5px;
@@ -36,11 +30,6 @@
         right: 0;
       }
 
-      .njg-searchBtn {
-        border: none;
-        border-radius: 5px;
-      }
-
       @media only screen and (max-width: 500px) {
         .njg-searchInput {
           width: 40%;
@@ -59,32 +48,31 @@
   </head>
 
   <body>
-     <div class="netjsongraph-container">
-     <div id="graphChartContainer"></div>
-   </div>
+    <div id="njg">
+      <div class="njg-relativePosition"></div>
+
+      <!-- Loading container -->
+      <div id="loadingContainer">
+        <div class="loadingElement">
+          <div class="loadingSprite"></div>
+          <div class="loadingTip">Loading...</div>
+        </div>
+      </div>
+    </div>
 
     <script type="text/javascript">
-      /*
-                  The demo is used to show the use of the `searchElements` function.
-                  For test, you can input `test` and click the `search` button.
-                  See the following comments for details.
-              */
-      // `graph` render defaultly.
       let graph = new NetJSONGraph("../assets/data/netjsonmap.json", {
-        container: "#graphChartContainer",
+        el: "#njg",
         onReady: function () {
           let searchContainer = document.createElement("div"),
             searchInput = document.createElement("input"),
             searchBtn = document.createElement("button"),
-            /*
-                              Pass in the url to listen to, and save the returned function.
-                              Please ensure that the return value of the api is the specified json format.
-                          */
             searchFunc = this.utils.searchElements.call(
               this,
               "https://ee3bdf59-d14c-4280-b514-52bd3dfc2c17.mock.pstmn.io/?search=",
             );
 
+          // ...existing code for search setup...
           searchInput.setAttribute("class", "njg-searchInput");
           searchInput.placeholder =
             "Input value for searching special elements.";
@@ -95,24 +83,18 @@
           searchContainer.appendChild(searchBtn);
           this.el.appendChild(searchContainer);
 
+          // ...existing event handlers...
           searchInput.onchange = () => {
             // do something to deal user input value.
           };
 
           searchBtn.onclick = () => {
             let inputValue = searchInput.value.trim();
-
-            /*
-                              Pass in the relevant search value,
-                              which will re-render automatically according to the request result within the function.
-                          */
             if (inputValue === "appendData") {
-              // appendData
               searchFunc(inputValue, false);
             } else {
               searchFunc(inputValue);
             }
-
             searchInput.value = "";
           };
         },

--- a/public/example_templates/netjson-searchElements.html
+++ b/public/example_templates/netjson-searchElements.html
@@ -15,19 +15,6 @@
         width: 100%;
       }
 
-      .netjsongraph-container {
-        position: absolute;
-        top: 0;
-        left: 0;
-        width: 100%;
-        height: 100%;
-      }
-
-      #graphChartContainer {
-        width: 100%;
-        height: 100%;
-      }
-
       .njg-searchBtn {
         border: none;
         border-radius: 5px;

--- a/public/example_templates/netjson-searchElements.html
+++ b/public/example_templates/netjson-searchElements.html
@@ -8,6 +8,26 @@
     <link href="../lib/css/netjsongraph-theme.css" rel="stylesheet" />
     <link href="../lib/css/netjsongraph.css" rel="stylesheet" />
     <style>
+       html, body {
+        margin: 0;
+        padding: 0;
+        height: 100%;
+        width: 100%;
+      }
+
+      .netjsongraph-container {
+        position: absolute;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+      }
+
+      #graphChartContainer {
+        width: 100%;
+        height: 100%;
+      }
+
       .njg-searchBtn {
         border: none;
         border-radius: 5px;
@@ -52,6 +72,10 @@
   </head>
 
   <body>
+     <div class="netjsongraph-container">
+     <div id="graphChartContainer"></div>
+   </div>
+
     <script type="text/javascript">
       /*
                   The demo is used to show the use of the `searchElements` function.
@@ -60,6 +84,7 @@
               */
       // `graph` render defaultly.
       let graph = new NetJSONGraph("../assets/data/netjsonmap.json", {
+        container: "#graphChartContainer",
         onReady: function () {
           let searchContainer = document.createElement("div"),
             searchInput = document.createElement("input"),

--- a/public/example_templates/netjson-switchGraphMode.html
+++ b/public/example_templates/netjson-switchGraphMode.html
@@ -22,19 +22,6 @@
         width: 100%;
       }
 
-      .netjsongraph-container {
-        position: absolute;
-        top: 0;
-        left: 0;
-        width: 100%;
-        height: 100%;
-      }
-
-      #graphChartContainer {
-        width: 100%;
-        height: 100%;
-      }
-
       .leaflet-control-zoom {
         top: 55px;
         right: 1px;

--- a/public/example_templates/netjson-switchGraphMode.html
+++ b/public/example_templates/netjson-switchGraphMode.html
@@ -15,6 +15,26 @@
     <link href="../lib/css/netjsongraph-theme.css" rel="stylesheet" />
     <link href="../lib/css/netjsongraph.css" rel="stylesheet" />
     <style type="text/css">
+      html, body {
+        margin: 0;
+        padding: 0;
+        height: 100%;
+        width: 100%;
+      }
+
+      .netjsongraph-container {
+        position: absolute;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+      }
+
+      #graphChartContainer {
+        width: 100%;
+        height: 100%;
+      }
+
       .leaflet-control-zoom {
         top: 55px;
         right: 1px;
@@ -22,12 +42,17 @@
     </style>
   </head>
   <body>
+    <div class="netjsongraph-container">
+     <div id="graphChartContainer"></div>
+   </div>
+
     <script type="text/javascript">
       /*
           The demo is used to show how to switch the netjsongraph render mode -- `graph` or `map`.
       */
       const map = new NetJSONGraph("../assets/data/netjsonmap.json", {
         render: "map",
+        container: "#graphChartContainer",
         switchMode: true,
         // set map initial state.
         mapOptions: {

--- a/public/example_templates/netjson-switchGraphMode.html
+++ b/public/example_templates/netjson-switchGraphMode.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
     <title>netjsongraph.js: basic example</title>
@@ -11,17 +11,10 @@
       crossorigin=""
     />
     <link href="../lib/css/leaflet-draw.css" rel="stylesheet" />
-    <!-- theme can be easily customized via css -->
     <link href="../lib/css/netjsongraph-theme.css" rel="stylesheet" />
     <link href="../lib/css/netjsongraph.css" rel="stylesheet" />
+    <link href="../assets/css/examples.css" rel="stylesheet" />
     <style type="text/css">
-      html, body {
-        margin: 0;
-        padding: 0;
-        height: 100%;
-        width: 100%;
-      }
-
       .leaflet-control-zoom {
         top: 55px;
         right: 1px;
@@ -29,19 +22,23 @@
     </style>
   </head>
   <body>
-    <div class="netjsongraph-container">
-     <div id="graphChartContainer"></div>
-   </div>
+    <div id="njg">
+      <div class="njg-relativePosition"></div>
+
+      <!-- Loading container -->
+      <div id="loadingContainer">
+        <div class="loadingElement">
+          <div class="loadingSprite"></div>
+          <div class="loadingTip">Loading...</div>
+        </div>
+      </div>
+    </div>
 
     <script type="text/javascript">
-      /*
-          The demo is used to show how to switch the netjsongraph render mode -- `graph` or `map`.
-      */
       const map = new NetJSONGraph("../assets/data/netjsonmap.json", {
         render: "map",
-        container: "#graphChartContainer",
+        el: "#njg",
         switchMode: true,
-        // set map initial state.
         mapOptions: {
           center: [46.86764405052012, 19.675998687744144],
           zoom: 5,
@@ -51,7 +48,6 @@
             },
           },
         },
-        // Convert to internal json format
         prepareData: (data) => {
           data.nodes.map((node) => {
             node.label = node.name;

--- a/public/example_templates/netjson-switchRenderMode.html
+++ b/public/example_templates/netjson-switchRenderMode.html
@@ -16,19 +16,6 @@
         width: 100%;
       }
 
-      .netjsongraph-container {
-        position: absolute;
-        top: 0;
-        left: 0;
-        width: 100%;
-        height: 100%;
-      }
-
-      #graphChartContainer {
-        width: 100%;
-        height: 100%;
-      }
-
       .switch-wrap input[type="checkbox"] {
         height: 0;
         width: 0;

--- a/public/example_templates/netjson-switchRenderMode.html
+++ b/public/example_templates/netjson-switchRenderMode.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
     <title>netjsongraph.js: basic example</title>
@@ -8,6 +8,27 @@
     <link href="../lib/css/netjsongraph-theme.css" rel="stylesheet" />
     <link href="../lib/css/netjsongraph.css" rel="stylesheet" />
     <style>
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+        height: 100%;
+        width: 100%;
+      }
+
+      .netjsongraph-container {
+        position: absolute;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+      }
+
+      #graphChartContainer {
+        width: 100%;
+        height: 100%;
+      }
+
       .switch-wrap input[type="checkbox"] {
         height: 0;
         width: 0;
@@ -28,11 +49,15 @@
   </head>
 
   <body>
+    <div class="netjsongraph-container">
+      <div id="graphChartContainer"></div>
+    </div>
     <script type="text/javascript">
       /*
           The demo is used to show how to switch the netjsongraph render mode -- `svg` or `canvas`.
       */
       const graph = new NetJSONGraph("../assets/data/netjsonmap.json", {
+        container: "#graphChartContainer",
         onReady: function () {
           switchRenderMode(this);
         },

--- a/public/example_templates/netjson-switchRenderMode.html
+++ b/public/example_templates/netjson-switchRenderMode.html
@@ -7,6 +7,7 @@
     <!-- theme can be easily customized via css -->
     <link href="../lib/css/netjsongraph-theme.css" rel="stylesheet" />
     <link href="../lib/css/netjsongraph.css" rel="stylesheet" />
+    <link href="../assets/css/examples.css" rel="stylesheet" />
     <style>
       html,
       body {
@@ -36,15 +37,23 @@
   </head>
 
   <body>
-    <div class="netjsongraph-container">
-      <div id="graphChartContainer"></div>
+    <div id="njg">
+      <div class="njg-relativePosition"></div>
+
+      <!-- Loading container -->
+      <div id="loadingContainer">
+        <div class="loadingElement">
+          <div class="loadingSprite"></div>
+          <div class="loadingTip">Loading...</div>
+        </div>
+      </div>
     </div>
     <script type="text/javascript">
       /*
           The demo is used to show how to switch the netjsongraph render mode -- `svg` or `canvas`.
       */
       const graph = new NetJSONGraph("../assets/data/netjsonmap.json", {
-        container: "#graphChartContainer",
+        el: "#njg",
         onReady: function () {
           switchRenderMode(this);
         },

--- a/public/example_templates/netjsongraph-elementsLegend.html
+++ b/public/example_templates/netjsongraph-elementsLegend.html
@@ -1,221 +1,229 @@
-<!DOCTYPE html>
-<head>
-  <title>netjsongraph.js: basic example</title>
-  <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <!-- theme can be easily customized via css -->
-  <link href="../lib/css/netjsongraph-theme.css" rel="stylesheet" />
-  <link href="../lib/css/netjsongraph.css" rel="stylesheet" />
-  <style>
-    html, body {
-        margin: 0;
-        padding: 0;
-        height: 100%;
-        width: 100%;
+<!doctype html>
+<html lang="en">
+  <head>
+    <title>netjsongraph.js: basic example</title>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <!-- theme can be easily customized via css -->
+    <link href="../lib/css/netjsongraph-theme.css" rel="stylesheet" />
+    <link href="../lib/css/netjsongraph.css" rel="stylesheet" />
+    <link href="../assets/css/examples.css" rel="stylesheet" />
+    <style>
+      #legend h4 {
+        margin: 10px 0;
+        text-align: center;
       }
 
-    #legend h4 {
-      margin: 10px 0;
-      text-align: center;
-    }
-
-    #legend {
-      position: absolute;
-      top: auto;
-      right: 15px;
-      bottom: 15px;
-      width: auto;
-      height: auto;
-      max-width: 250px;
-      padding: 0 15px;
-      background: #fbfbfb;
-      border-radius: 8px;
-      border: 1px solid #ccc;
-      color: #6d6357;
-      font-family: Arial, sans-serif;
-      font-family: sans-serif;
-      font-size: 14px;
-      z-index: 2;
-    }
-
-    #legend p {
-      margin: 10px 0;
-      display: flex;
-      align-items: center;
-    }
-
-    #legend span {
-      width: 16px;
-      margin-right: 5px;
-    }
-
-    #legend span.circle {
-      display: inline-block;
-      border-radius: 50%;
-      height: 16px;
-    }
-
-    #legend span.link {
-      display: inline-block;
-      height: 5px;
-      border-bottom-width: 6px;
-      border-bottom-style: solid;
-    }
-
-    #legend .node {
-      background-color: #3182bd;
-    }
-
-    #legend .gateway {
-      background-color: #ff8000;
-    }
-
-    #legend .wireless {
-      border-color: #669999;
-    }
-
-    #legend .ethernet {
-      border-color: #00ff00;
-    }
-
-    @media only screen and (max-width: 850px) {
       #legend {
+        position: absolute;
+        top: auto;
         right: 15px;
+        bottom: 15px;
+        width: auto;
+        height: auto;
+        max-width: 250px;
+        padding: 0 15px;
+        background: #fbfbfb;
+        border-radius: 8px;
+        border: 1px solid #ccc;
+        color: #6d6357;
+        font-family: Arial, sans-serif;
+        font-size: 14px;
+        z-index: 2;
       }
-    }
-  </style>
-</head>
- <div class="netjsongraph-container">
-    <div id="graphChartContainer"></div>
-    <div id="legend">
-      <h4>Legends</h4>
-      <p><span class="circle node">&nbsp;</span> ordinary node</p>
-      <p><span class="circle gateway">&nbsp;</span> gateway node</p>
-      <p><span class="link wireless">&nbsp;</span> wireless link</p>
-      <p><span class="link ethernet">&nbsp;</span> ethernet link</p>
+
+      #legend p {
+        margin: 10px 0;
+        display: flex;
+        align-items: center;
+      }
+
+      #legend span {
+        width: 16px;
+        margin-right: 5px;
+      }
+
+      #legend span.circle {
+        display: inline-block;
+        border-radius: 50%;
+        height: 16px;
+      }
+
+      #legend span.link {
+        display: inline-block;
+        height: 5px;
+        border-bottom-width: 6px;
+        border-bottom-style: solid;
+      }
+
+      #legend .node {
+        background-color: #3182bd;
+      }
+      #legend .gateway {
+        background-color: #ff8000;
+      }
+      #legend .wireless {
+        border-color: #669999;
+      }
+      #legend .ethernet {
+        border-color: #00ff00;
+      }
+
+      @media only screen and (max-width: 850px) {
+        #legend {
+          right: 15px;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <div id="njg">
+      <div class="njg-relativePosition"></div>
+
+      <div id="legend">
+        <h4>Legends</h4>
+        <p><span class="circle node">&nbsp;</span> ordinary node</p>
+        <p><span class="circle gateway">&nbsp;</span> gateway node</p>
+        <p><span class="link wireless">&nbsp;</span> wireless link</p>
+        <p><span class="link ethernet">&nbsp;</span> ethernet link</p>
+      </div>
+
+      <!-- Loading container -->
+      <div id="loadingContainer">
+        <div class="loadingElement">
+          <div class="loadingSprite"></div>
+          <div class="loadingTip">Loading...</div>
+        </div>
+      </div>
     </div>
-  </div>
-  <script type="text/javascript">
-    /*
+
+    <script type="text/javascript">
+      /*
           The demo is used to show how to set colorful nodes.
       */
-    const graph = new NetJSONGraph("../assets/data/netjson-elementsLegend.json", {
-      container: "#graphChartContainer",
-      graphConfig: {
-        series: {
-          force: {
-            gravity: 0.1,
-            edgeLength: [80, 100],
-            repulsion: 2000,
-          },
-          nodeSize: 30,
-          linkStyle: {
-            width: 10,
-          },
-          emphasis: {
-            disabled: true,
-          }
-        },
-      },
-      nodeCategories: [
+      const graph = new NetJSONGraph(
+        "../assets/data/netjson-elementsLegend.json",
         {
-          name: "gateway",
-          nodeStyle: {
-            color: {
-              type: "radial",
-              x: 0.5,
-              y: 0.5,
-              r: 0.5,
-              colorStops: [
-                {
-                  offset: 0,
-                  color: "#f18d3a",
-                },
-                {
-                  offset: 0.7,
-                  color: "#f18d3a",
-                },
-                {
-                  offset: 0.71,
-                  color: "#f8c69d",
-                },
-                {
-                  offset: 1,
-                  color: "#f8c69d",
-                },
-              ],
-              global: false,
+          el: "#njg",
+          graphConfig: {
+            series: {
+              force: {
+                gravity: 0.1,
+                edgeLength: [80, 100],
+                repulsion: 2000,
+              },
+              nodeSize: 30,
+              linkStyle: {
+                width: 10,
+              },
+              emphasis: {
+                disabled: true,
+              },
             },
           },
-          nodeSize: 30,
-        },
-        {
-          name: "default",
-          nodeStyle: {
-            color: {
-              type: "radial",
-              x: 0.5,
-              y: 0.5,
-              r: 0.5,
-              colorStops: [
-                {
-                  offset: 0,
-                  color: "#3d83b5",
+          nodeCategories: [
+            {
+              name: "gateway",
+              nodeStyle: {
+                color: {
+                  type: "radial",
+                  x: 0.5,
+                  y: 0.5,
+                  r: 0.5,
+                  colorStops: [
+                    {
+                      offset: 0,
+                      color: "#f18d3a",
+                    },
+                    {
+                      offset: 0.7,
+                      color: "#f18d3a",
+                    },
+                    {
+                      offset: 0.71,
+                      color: "#f8c69d",
+                    },
+                    {
+                      offset: 1,
+                      color: "#f8c69d",
+                    },
+                  ],
+                  global: false,
                 },
-                {
-                  offset: 0.7,
-                  color: "#3d83b5",
-                },
-                {
-                  offset: 0.71,
-                  color: "#9ec1da",
-                },
-                {
-                  offset: 1,
-                  color: "#9ec1da",
-                },
-              ],
-              global: false,
+              },
+              nodeSize: 30,
             },
-          },
-          nodeSize: 30,
-        },
-      ],
-      linkCategories: [
-        {
-          name: "wireless",
-          linkStyle: {
-            color: "#669999",
-            width: 10,
-          },
-        },
-        {
-          name: "ethernet",
-          linkStyle: {
-            color: "#00ff00",
-            opacity: 0.7,
-            width: 10,
-          },
-        },
-      ],
+            {
+              name: "default",
+              nodeStyle: {
+                color: {
+                  type: "radial",
+                  x: 0.5,
+                  y: 0.5,
+                  r: 0.5,
+                  colorStops: [
+                    {
+                      offset: 0,
+                      color: "#3d83b5",
+                    },
+                    {
+                      offset: 0.7,
+                      color: "#3d83b5",
+                    },
+                    {
+                      offset: 0.71,
+                      color: "#9ec1da",
+                    },
+                    {
+                      offset: 1,
+                      color: "#9ec1da",
+                    },
+                  ],
+                  global: false,
+                },
+              },
+              nodeSize: 30,
+            },
+          ],
+          linkCategories: [
+            {
+              name: "wireless",
+              linkStyle: {
+                color: "#669999",
+                width: 10,
+              },
+            },
+            {
+              name: "ethernet",
+              linkStyle: {
+                color: "#00ff00",
+                opacity: 0.7,
+                width: 10,
+              },
+            },
+          ],
 
-      prepareData: (data) => {
-        data.nodes.map((node) => {
-          if (node.properties.gateway) {
-            node.category = "gateway";
-          } else {
-            node.category = "default";
-          }
-        });
-        data.links.map((link) => {
-          if (link.properties.type === 'wireless' || link.properties.type === 'ethernet') {
-            link.category = link.properties.type;
-          }
-        });
-      },
-    });
+          prepareData: (data) => {
+            data.nodes.map((node) => {
+              if (node.properties.gateway) {
+                node.category = "gateway";
+              } else {
+                node.category = "default";
+              }
+            });
+            data.links.map((link) => {
+              if (
+                link.properties.type === "wireless" ||
+                link.properties.type === "ethernet"
+              ) {
+                link.category = link.properties.type;
+              }
+            });
+          },
+        },
+      );
 
-    graph.render();
-  </script>
-</body>
+      graph.render();
+    </script>
+  </body>
 </html>

--- a/public/example_templates/netjsongraph-elementsLegend.html
+++ b/public/example_templates/netjsongraph-elementsLegend.html
@@ -7,12 +7,25 @@
   <link href="../lib/css/netjsongraph-theme.css" rel="stylesheet" />
   <link href="../lib/css/netjsongraph.css" rel="stylesheet" />
   <style>
-    #container {
-      width: 100%;
-      height: 100%;
-      overflow: hidden;
-      overflow-y: scroll;
-    }
+    html, body {
+        margin: 0;
+        padding: 0;
+        height: 100%;
+        width: 100%;
+      }
+
+      .netjsongraph-container {
+        position: absolute;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+      }
+
+      #graphChartContainer {
+        width: 100%;
+        height: 100%;
+      }
 
     #legend h4 {
       margin: 10px 0;
@@ -85,21 +98,22 @@
     }
   </style>
 </head>
-<body>
-  <div id="legend">
-    <h4>Legends</h4>
-    <p><span class="circle node">&nbsp;</span> ordinary node</p>
-    <p><span class="circle gateway">&nbsp;</span> gateway node</p>
-    <p><span class="link wireless">&nbsp;</span> wireless link</p>
-    <p><span class="link ethernet">&nbsp;</span> ethernet link</p>
+ <div class="netjsongraph-container">
+    <div id="graphChartContainer"></div>
+    <div id="legend">
+      <h4>Legends</h4>
+      <p><span class="circle node">&nbsp;</span> ordinary node</p>
+      <p><span class="circle gateway">&nbsp;</span> gateway node</p>
+      <p><span class="link wireless">&nbsp;</span> wireless link</p>
+      <p><span class="link ethernet">&nbsp;</span> ethernet link</p>
+    </div>
   </div>
-  <div id="container"></div>
   <script type="text/javascript">
     /*
           The demo is used to show how to set colorful nodes.
       */
     const graph = new NetJSONGraph("../assets/data/netjson-elementsLegend.json", {
-      el: "#container",
+      container: "#graphChartContainer",
       graphConfig: {
         series: {
           force: {

--- a/public/example_templates/netjsongraph-elementsLegend.html
+++ b/public/example_templates/netjsongraph-elementsLegend.html
@@ -14,19 +14,6 @@
         width: 100%;
       }
 
-      .netjsongraph-container {
-        position: absolute;
-        top: 0;
-        left: 0;
-        width: 100%;
-        height: 100%;
-      }
-
-      #graphChartContainer {
-        width: 100%;
-        height: 100%;
-      }
-
     #legend h4 {
       margin: 10px 0;
       text-align: center;

--- a/public/example_templates/netjsongraph-graphGL.html
+++ b/public/example_templates/netjsongraph-graphGL.html
@@ -14,19 +14,6 @@
         height: 100%;
         width: 100%;
       }
-
-      .netjsongraph-container {
-        position: absolute;
-        top: 0;
-        left: 0;
-        width: 100%;
-        height: 100%;
-      }
-
-      #graphChartContainer {
-        width: 100%;
-        height: 100%;
-      }
     </style>
   </head>
   <body>

--- a/public/example_templates/netjsongraph-graphGL.html
+++ b/public/example_templates/netjsongraph-graphGL.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
     <title>netjsongraph.js: basic example</title>
@@ -7,28 +7,29 @@
     <!-- theme can be easily customized via css -->
     <link href="../lib/css/netjsongraph-theme.css" rel="stylesheet" />
     <link href="../lib/css/netjsongraph.css" rel="stylesheet" />
-    <style>
-       html, body {
-        margin: 0;
-        padding: 0;
-        height: 100%;
-        width: 100%;
-      }
-    </style>
+    <link href="../assets/css/examples.css" rel="stylesheet" />
   </head>
   <body>
-    <div class="netjsongraph-container">
-      <div id="graphChartContainer"></div>
+    <div id="njg">
+      <div class="njg-relativePosition"></div>
+
+      <!-- Loading container -->
+      <div id="loadingContainer">
+        <div class="loadingElement">
+          <div class="loadingSprite"></div>
+          <div class="loadingTip">Loading...</div>
+        </div>
+      </div>
     </div>
+
     <script type="text/javascript">
       /*
           The demo is used to show how to use `graphGL` to render big data.
       */
-      // `graph` render defaultly.
       const graph = new NetJSONGraph(
         "../assets/data/netjsongraph-graphGL.json",
         {
-          container: "#graphChartContainer",
+          el: "#njg",
           graphConfig: {
             series: {
               type: "graphGL",
@@ -53,7 +54,6 @@
                 textStyle: {
                   color: "#fff",
                 },
-                // graphGL render must set it !!!
                 show: false,
               },
               focusNodeAdjacency: false,
@@ -66,7 +66,6 @@
                   width: 4,
                 },
               },
-              // set force layout params
               forceAtlas2: {
                 steps: 5,
                 stopThreshold: 20,

--- a/public/example_templates/netjsongraph-graphGL.html
+++ b/public/example_templates/netjsongraph-graphGL.html
@@ -7,8 +7,32 @@
     <!-- theme can be easily customized via css -->
     <link href="../lib/css/netjsongraph-theme.css" rel="stylesheet" />
     <link href="../lib/css/netjsongraph.css" rel="stylesheet" />
+    <style>
+       html, body {
+        margin: 0;
+        padding: 0;
+        height: 100%;
+        width: 100%;
+      }
+
+      .netjsongraph-container {
+        position: absolute;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+      }
+
+      #graphChartContainer {
+        width: 100%;
+        height: 100%;
+      }
+    </style>
   </head>
   <body>
+    <div class="netjsongraph-container">
+      <div id="graphChartContainer"></div>
+    </div>
     <script type="text/javascript">
       /*
           The demo is used to show how to use `graphGL` to render big data.
@@ -17,6 +41,7 @@
       const graph = new NetJSONGraph(
         "../assets/data/netjsongraph-graphGL.json",
         {
+          container: "#graphChartContainer",
           graphConfig: {
             series: {
               type: "graphGL",

--- a/public/example_templates/netjsongraph-multipleLinks.html
+++ b/public/example_templates/netjsongraph-multipleLinks.html
@@ -14,19 +14,6 @@
         height: 100%;
         width: 100%;
       }
-
-      .netjsongraph-container {
-        position: absolute;
-        top: 0;
-        left: 0;
-        width: 100%;
-        height: 100%;
-      }
-
-      #graphChartContainer {
-        width: 100%;
-        height: 100%;
-      }
     </style>
   </head>
 

--- a/public/example_templates/netjsongraph-multipleLinks.html
+++ b/public/example_templates/netjsongraph-multipleLinks.html
@@ -7,9 +7,33 @@
     <!-- theme can be easily customized via css -->
     <link href="../lib/css/netjsongraph-theme.css" rel="stylesheet" />
     <link href="../lib/css/netjsongraph.css" rel="stylesheet" />
+    <style>
+      html, body {
+        margin: 0;
+        padding: 0;
+        height: 100%;
+        width: 100%;
+      }
+
+      .netjsongraph-container {
+        position: absolute;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+      }
+
+      #graphChartContainer {
+        width: 100%;
+        height: 100%;
+      }
+    </style>
   </head>
 
   <body>
+    <div class="netjsongraph-container">
+      <div id="graphChartContainer"></div>
+    </div>
     <script type="text/javascript">
       /*
             The demo is used to show the multiple links render.
@@ -19,6 +43,7 @@
       const graph = new NetJSONGraph(
         "../assets/data/netjsongraph-multipleLinks.json",
         {
+          container: "#graphChartContainer",
           graphConfig: {
             // set force layout params
             force: {

--- a/public/example_templates/netjsongraph-multipleLinks.html
+++ b/public/example_templates/netjsongraph-multipleLinks.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
     <title>netjsongraph.js: basic example</title>
@@ -7,30 +7,31 @@
     <!-- theme can be easily customized via css -->
     <link href="../lib/css/netjsongraph-theme.css" rel="stylesheet" />
     <link href="../lib/css/netjsongraph.css" rel="stylesheet" />
-    <style>
-      html, body {
-        margin: 0;
-        padding: 0;
-        height: 100%;
-        width: 100%;
-      }
-    </style>
+    <link href="../assets/css/examples.css" rel="stylesheet" />
   </head>
 
   <body>
-    <div class="netjsongraph-container">
-      <div id="graphChartContainer"></div>
+    <div id="njg">
+      <div class="njg-relativePosition"></div>
+
+      <!-- Loading container -->
+      <div id="loadingContainer">
+        <div class="loadingElement">
+          <div class="loadingSprite"></div>
+          <div class="loadingTip">Loading...</div>
+        </div>
+      </div>
     </div>
+
     <script type="text/javascript">
       /*
-            The demo is used to show the multiple links render.
-            Currently only supports up to two links.
-        */
-      // `graph` render defaultly.
+          The demo is used to show the multiple links render.
+          Currently only supports up to two links.
+      */
       const graph = new NetJSONGraph(
         "../assets/data/netjsongraph-multipleLinks.json",
         {
-          container: "#graphChartContainer",
+          el: "#njg",
           graphConfig: {
             // set force layout params
             force: {

--- a/public/example_templates/netjsongraph-nodeExpand.html
+++ b/public/example_templates/netjsongraph-nodeExpand.html
@@ -14,19 +14,6 @@
         height: 100%;
         width: 100%;
       }
-
-      .netjsongraph-container {
-        position: absolute;
-        top: 0;
-        left: 0;
-        width: 100%;
-        height: 100%;
-      }
-
-      #graphChartContainer {
-        width: 100%;
-        height: 100%;
-      }
     </style>
   </head>
   <body>

--- a/public/example_templates/netjsongraph-nodeExpand.html
+++ b/public/example_templates/netjsongraph-nodeExpand.html
@@ -7,8 +7,32 @@
     <!-- theme can be easily customized via css -->
     <link href="../lib/css/netjsongraph-theme.css" rel="stylesheet" />
     <link href="../lib/css/netjsongraph.css" rel="stylesheet" />
+    <style>
+        html, body {
+        margin: 0;
+        padding: 0;
+        height: 100%;
+        width: 100%;
+      }
+
+      .netjsongraph-container {
+        position: absolute;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+      }
+
+      #graphChartContainer {
+        width: 100%;
+        height: 100%;
+      }
+    </style>
   </head>
   <body>
+    <div class="netjsongraph-container">
+      <div id="graphChartContainer"></div>
+    </div>
     <script type="text/javascript">
       /*
           The demo is used to show hwo to interact with elements.
@@ -17,6 +41,7 @@
       const graph = new NetJSONGraph(
         "../assets/data/netjsongraph-foldNodes.json",
         {
+          container: "#graphChartContainer",
           dealDataByWorker: "../lib/js/netjsonWorker.js",
           echartsOption: {
             legend: {

--- a/public/example_templates/netjsongraph-nodeExpand.html
+++ b/public/example_templates/netjsongraph-nodeExpand.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
     <title>netjsongraph.js: basic example</title>
@@ -7,28 +7,29 @@
     <!-- theme can be easily customized via css -->
     <link href="../lib/css/netjsongraph-theme.css" rel="stylesheet" />
     <link href="../lib/css/netjsongraph.css" rel="stylesheet" />
-    <style>
-        html, body {
-        margin: 0;
-        padding: 0;
-        height: 100%;
-        width: 100%;
-      }
-    </style>
+    <link href="../assets/css/examples.css" rel="stylesheet" />
   </head>
   <body>
-    <div class="netjsongraph-container">
-      <div id="graphChartContainer"></div>
+    <div id="njg">
+      <div class="njg-relativePosition"></div>
+
+      <!-- Loading container -->
+      <div id="loadingContainer">
+        <div class="loadingElement">
+          <div class="loadingSprite"></div>
+          <div class="loadingTip">Loading...</div>
+        </div>
+      </div>
     </div>
+
     <script type="text/javascript">
       /*
-          The demo is used to show hwo to interact with elements.
+          The demo is used to show how to interact with elements.
       */
-      // `graph` render defaultly.
       const graph = new NetJSONGraph(
         "../assets/data/netjsongraph-foldNodes.json",
         {
-          container: "#graphChartContainer",
+          el: "#njg",
           dealDataByWorker: "../lib/js/netjsonWorker.js",
           echartsOption: {
             legend: {

--- a/public/example_templates/netjsongraph.html
+++ b/public/example_templates/netjsongraph.html
@@ -1,119 +1,145 @@
 <!DOCTYPE html>
 <html lang="en">
-  <head>
-    <title>netjsongraph.js: basic example</title>
-    <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <!-- theme can be easily customized via css -->
-    <link href="../lib/css/netjsongraph-theme.css" rel="stylesheet" />
-    <link href="../lib/css/netjsongraph.css" rel="stylesheet" />
-    <style>
-      #legend h4 {
-        margin: 10px 0;
-        text-align: center;
-      }
-      #legend {
-        position: absolute;
-        right: 25px;
-        bottom: 25px;
-        width: auto;
-        height: auto;
-        max-width: 250px;
-        padding: 8px 15px;
-        background: #fbfbfb;
-        border-radius: 8px;
-        color: #000;
-        font-family: Arial, sans-serif;
-        font-family: sans-serif;
-        font-size: 14px;
-        z-index: 2;
-        user-select: text;
-      }
-      #legend p {
-        margin: 10px 0;
-        display: flex;
-        align-items: center;
-      }
-      #legend span {
-        width: 16px;
-        margin-right: 5px;
-      }
-      #legend .link-up,
-      #legend .link-down {
-        display: inline-block;
-        height: 5px;
-        border-bottom-width: 6px;
-        border-bottom-style: solid;
-      }
-      #legend .link-up {
-        color: #3acc38;
-        margin-right: 10px;
-      }
-      #legend .link-down {
-        color: red;
-        margin-right: 10px;
-      }
+ <head>
+   <title>netjsongraph.js: basic example</title>
+   <meta charset="utf-8" />
+   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+   <link href="../lib/css/netjsongraph-theme.css" rel="stylesheet" />
+   <link href="../lib/css/netjsongraph.css" rel="stylesheet" />
+   <style>
+     html, body {
+       margin: 0;
+       padding: 0;
+       height: 100%;
+       width: 100%;
+     }
 
-      @media only screen and (max-width: 850px) {
-        #legend {
-          right: 15px;
-        }
-      }
-    </style>
-  </head>
+     .netjsongraph-container {
+       position: absolute;
+       top: 0;
+       left: 0;
+       width: 100%;
+       height: 100%;
+     }
 
-  <body>
-    <script type="text/javascript">
-      // `graph` render defaultly.
-      // We can add data gradually by array.
-      const graph = new NetJSONGraph("../assets/data/netjsonmap.json", {
-        linkCategories: [
-          {
-            name: "down",
-            linkStyle: {
-              color: "#c92517",
-              width: 5,
-            },
-            emphasis: {
-              linkStyle: {
-                color: "#FD0101",
-                opacity: 1,
-              },
-            },
-          },
-        ],
-        prepareData: (data) => {
-          data.links.map((link) => {
-            link.properties = link.properties || {};
-            if (link.properties.status) {
-              link.category = link.properties.status;
-            }
-          });
-        },
-      });
-      const createLegend = (key, name) => {
-        const legendItem = document.createElement("p");
-        const legendIcon = document.createElement("span");
+     #graphChartContainer {
+       width: 100%;
+       height: 100%;
+     }
 
-        legendIcon.setAttribute("class", name);
+     #legend h4 {
+       margin: 10px 0;
+       text-align: center;
+     }
+     
+     #legend {
+       position: absolute;
+       right: 25px;
+       bottom: 25px;
+       width: auto;
+       height: auto;
+       max-width: 250px;
+       padding: 8px 15px;
+       background: #fbfbfb;
+       border-radius: 8px;
+       color: #000;
+       font-family: Arial, sans-serif;
+       font-size: 14px;
+       z-index: 2;
+       user-select: text;
+     }
 
-        legends.appendChild(legendItem);
-        legendItem.appendChild(legendIcon);
+     #legend p {
+       margin: 10px 0;
+       display: flex;
+       align-items: center;
+     }
 
-        legendItem.innerHTML += key;
-        return legendItem;
-      };
-      const legends = document.createElement("div");
-      const legendsHeader = document.createElement("h4");
-      legends.setAttribute("id", "legend");
-      legendsHeader.innerHTML = "Legend";
-      legends.appendChild(legendsHeader);
-      legends.appendChild(createLegend("Up", "link-up"));
-      legends.appendChild(createLegend("Down", "link-down"));
+     #legend span {
+       width: 16px;
+       margin-right: 5px;
+     }
 
-      document.body.appendChild(legends);
+     #legend .link-up,
+     #legend .link-down {
+       display: inline-block;
+       height: 5px;
+       border-bottom-width: 6px;
+       border-bottom-style: solid;
+     }
 
-      graph.render();
-    </script>
-  </body>
+     #legend .link-up {
+       color: #3acc38;
+       margin-right: 10px;
+     }
+
+     #legend .link-down {
+       color: red;
+       margin-right: 10px;
+     }
+
+     @media only screen and (max-width: 850px) {
+       #legend {
+         right: 15px;
+       }
+     }
+   </style>
+ </head>
+
+ <body>
+   <div class="netjsongraph-container">
+     <div id="graphChartContainer"></div>
+   </div>
+
+   <script type="text/javascript">
+     const graph = new NetJSONGraph("../assets/data/netjsonmap.json", {
+       container: "#graphChartContainer",
+       linkCategories: [
+         {
+           name: "down",
+           linkStyle: {
+             color: "#c92517",
+             width: 5,
+           },
+           emphasis: {
+             linkStyle: {
+               color: "#FD0101",
+               opacity: 1,
+             },
+           },
+         },
+       ],
+       prepareData: (data) => {
+         data.links.map((link) => {
+           link.properties = link.properties || {};
+           if (link.properties.status) {
+             link.category = link.properties.status;
+           }
+         });
+       },
+     });
+
+     const createLegend = (key, name) => {
+       const legendItem = document.createElement("p");
+       const legendIcon = document.createElement("span");
+       legendIcon.setAttribute("class", name);
+       legends.appendChild(legendItem);
+       legendItem.appendChild(legendIcon);
+       legendItem.innerHTML += key;
+       return legendItem;
+     };
+
+     const legends = document.createElement("div");
+     const legendsHeader = document.createElement("h4");
+     legends.setAttribute("id", "legend");
+     legendsHeader.innerHTML = "Legend";
+     legends.appendChild(legendsHeader);
+     legends.appendChild(createLegend("Up", "link-up"));
+     legends.appendChild(createLegend("Down", "link-down"));
+
+     document.body.appendChild(legends);
+
+     graph.render();
+   </script>
+ </body>
 </html>

--- a/public/example_templates/netjsongraph.html
+++ b/public/example_templates/netjsongraph.html
@@ -14,19 +14,6 @@
        width: 100%;
      }
 
-     .netjsongraph-container {
-       position: absolute;
-       top: 0;
-       left: 0;
-       width: 100%;
-       height: 100%;
-     }
-
-     #graphChartContainer {
-       width: 100%;
-       height: 100%;
-     }
-
      #legend h4 {
        margin: 10px 0;
        text-align: center;

--- a/public/example_templates/netjsongraph.html
+++ b/public/example_templates/netjsongraph.html
@@ -1,132 +1,134 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
- <head>
-   <title>netjsongraph.js: basic example</title>
-   <meta charset="utf-8" />
-   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-   <link href="../lib/css/netjsongraph-theme.css" rel="stylesheet" />
-   <link href="../lib/css/netjsongraph.css" rel="stylesheet" />
-   <style>
-     html, body {
-       margin: 0;
-       padding: 0;
-       height: 100%;
-       width: 100%;
-     }
+  <head>
+    <title>netjsongraph.js: basic example</title>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link href="../lib/css/netjsongraph-theme.css" rel="stylesheet" />
+    <link href="../lib/css/netjsongraph.css" rel="stylesheet" />
+    <link href="../assets/css/examples.css" rel="stylesheet" />
+    <style>
+      #legend h4 {
+        margin: 10px 0;
+        text-align: center;
+      }
 
-     #legend h4 {
-       margin: 10px 0;
-       text-align: center;
-     }
-     
-     #legend {
-       position: absolute;
-       right: 25px;
-       bottom: 25px;
-       width: auto;
-       height: auto;
-       max-width: 250px;
-       padding: 8px 15px;
-       background: #fbfbfb;
-       border-radius: 8px;
-       color: #000;
-       font-family: Arial, sans-serif;
-       font-size: 14px;
-       z-index: 2;
-       user-select: text;
-     }
+      #legend {
+        position: absolute;
+        right: 25px;
+        bottom: 25px;
+        width: auto;
+        height: auto;
+        max-width: 250px;
+        padding: 8px 15px;
+        background: #fbfbfb;
+        border-radius: 8px;
+        color: #000;
+        font-family: "iconfont", Arial, sans-serif;
+        font-size: 14px;
+        z-index: 2;
+        user-select: text;
+      }
 
-     #legend p {
-       margin: 10px 0;
-       display: flex;
-       align-items: center;
-     }
+      #legend p {
+        margin: 10px 0;
+        display: flex;
+        align-items: center;
+      }
 
-     #legend span {
-       width: 16px;
-       margin-right: 5px;
-     }
+      #legend span {
+        width: 16px;
+        margin-right: 5px;
+      }
 
-     #legend .link-up,
-     #legend .link-down {
-       display: inline-block;
-       height: 5px;
-       border-bottom-width: 6px;
-       border-bottom-style: solid;
-     }
+      #legend .link-up,
+      #legend .link-down {
+        display: inline-block;
+        height: 5px;
+        border-bottom-width: 6px;
+        border-bottom-style: solid;
+      }
 
-     #legend .link-up {
-       color: #3acc38;
-       margin-right: 10px;
-     }
+      #legend .link-up {
+        color: #3acc38;
+        margin-right: 10px;
+      }
 
-     #legend .link-down {
-       color: red;
-       margin-right: 10px;
-     }
+      #legend .link-down {
+        color: red;
+        margin-right: 10px;
+      }
 
-     @media only screen and (max-width: 850px) {
-       #legend {
-         right: 15px;
-       }
-     }
-   </style>
- </head>
+      @media only screen and (max-width: 850px) {
+        #legend {
+          right: 15px;
+        }
+      }
+    </style>
+  </head>
 
- <body>
-   <div class="netjsongraph-container">
-     <div id="graphChartContainer"></div>
-   </div>
+  <body>
+    <div id="njg">
+      <div class="njg-relativePosition"></div>
 
-   <script type="text/javascript">
-     const graph = new NetJSONGraph("../assets/data/netjsonmap.json", {
-       container: "#graphChartContainer",
-       linkCategories: [
-         {
-           name: "down",
-           linkStyle: {
-             color: "#c92517",
-             width: 5,
-           },
-           emphasis: {
-             linkStyle: {
-               color: "#FD0101",
-               opacity: 1,
-             },
-           },
-         },
-       ],
-       prepareData: (data) => {
-         data.links.map((link) => {
-           link.properties = link.properties || {};
-           if (link.properties.status) {
-             link.category = link.properties.status;
-           }
-         });
-       },
-     });
+      <!-- Loading container -->
+      <div id="loadingContainer">
+        <div class="loadingElement">
+          <div class="loadingSprite"></div>
+          <div class="loadingTip">Loading...</div>
+        </div>
+      </div>
+    </div>
 
-     const createLegend = (key, name) => {
-       const legendItem = document.createElement("p");
-       const legendIcon = document.createElement("span");
-       legendIcon.setAttribute("class", name);
-       legends.appendChild(legendItem);
-       legendItem.appendChild(legendIcon);
-       legendItem.innerHTML += key;
-       return legendItem;
-     };
+    <script type="text/javascript">
+      const graph = new NetJSONGraph("../assets/data/netjsonmap.json", {
+        el: "#njg",
+        linkCategories: [
+          {
+            name: "down",
+            linkStyle: {
+              color: "#c92517",
+              width: 5,
+            },
+            emphasis: {
+              linkStyle: {
+                color: "#FD0101",
+                opacity: 1,
+              },
+            },
+          },
+        ],
+        prepareData: (data) => {
+          data.links.map((link) => {
+            link.properties = link.properties || {};
+            if (link.properties.status) {
+              link.category = link.properties.status;
+            }
+          });
+        },
+      });
 
-     const legends = document.createElement("div");
-     const legendsHeader = document.createElement("h4");
-     legends.setAttribute("id", "legend");
-     legendsHeader.innerHTML = "Legend";
-     legends.appendChild(legendsHeader);
-     legends.appendChild(createLegend("Up", "link-up"));
-     legends.appendChild(createLegend("Down", "link-down"));
+      const createLegend = (key, name) => {
+        const legendItem = document.createElement("p");
+        const legendIcon = document.createElement("span");
+        legendIcon.setAttribute("class", name);
+        legends.appendChild(legendItem);
+        legendItem.appendChild(legendIcon);
+        legendItem.innerHTML += key;
+        return legendItem;
+      };
 
-     document.body.appendChild(legends);
+      const legends = document.createElement("div");
+      const legendsHeader = document.createElement("h4");
+      legends.setAttribute("id", "legend");
+      legendsHeader.innerHTML = "Legend";
+      legends.appendChild(legendsHeader);
+      legends.appendChild(createLegend("Up", "link-up"));
+      legends.appendChild(createLegend("Down", "link-down"));
 
-     graph.render();
-   </script>
- </body>
+      document.body.appendChild(legends);
+
+      graph.render();
+    </script>
+  </body>
 </html>

--- a/public/example_templates/netjsongraph.html
+++ b/public/example_templates/netjsongraph.html
@@ -1,9 +1,10 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
   <head>
     <title>netjsongraph.js: basic example</title>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <!-- theme can be easily customized via css -->
     <link href="../lib/css/netjsongraph-theme.css" rel="stylesheet" />
     <link href="../lib/css/netjsongraph.css" rel="stylesheet" />
     <link href="../assets/css/examples.css" rel="stylesheet" />
@@ -12,7 +13,6 @@
         margin: 10px 0;
         text-align: center;
       }
-
       #legend {
         position: absolute;
         right: 25px;
@@ -24,23 +24,21 @@
         background: #fbfbfb;
         border-radius: 8px;
         color: #000;
-        font-family: "iconfont", Arial, sans-serif;
+        font-family: Arial, sans-serif;
+        font-family: sans-serif;
         font-size: 14px;
         z-index: 2;
         user-select: text;
       }
-
       #legend p {
         margin: 10px 0;
         display: flex;
         align-items: center;
       }
-
       #legend span {
         width: 16px;
         margin-right: 5px;
       }
-
       #legend .link-up,
       #legend .link-down {
         display: inline-block;
@@ -48,12 +46,10 @@
         border-bottom-width: 6px;
         border-bottom-style: solid;
       }
-
       #legend .link-up {
         color: #3acc38;
         margin-right: 10px;
       }
-
       #legend .link-down {
         color: red;
         margin-right: 10px;
@@ -70,6 +66,7 @@
   <body>
     <div id="njg">
       <div class="njg-relativePosition"></div>
+    </div>
 
       <!-- Loading container -->
       <div id="loadingContainer">
@@ -78,9 +75,9 @@
           <div class="loadingTip">Loading...</div>
         </div>
       </div>
-    </div>
-
     <script type="text/javascript">
+      // `graph` render defaultly.
+      // We can add data gradually by array.
       const graph = new NetJSONGraph("../assets/data/netjsonmap.json", {
         el: "#njg",
         linkCategories: [
@@ -107,17 +104,18 @@
           });
         },
       });
-
       const createLegend = (key, name) => {
         const legendItem = document.createElement("p");
         const legendIcon = document.createElement("span");
+
         legendIcon.setAttribute("class", name);
+
         legends.appendChild(legendItem);
         legendItem.appendChild(legendIcon);
+
         legendItem.innerHTML += key;
         return legendItem;
       };
-
       const legends = document.createElement("div");
       const legendsHeader = document.createElement("h4");
       legends.setAttribute("id", "legend");

--- a/public/example_templates/netjsonmap-animation.html
+++ b/public/example_templates/netjsonmap-animation.html
@@ -20,19 +20,6 @@
         height: 100%;
         width: 100%;
       }
-
-      .netjsongraph-container {
-        position: absolute;
-        top: 0;
-        left: 0;
-        width: 100%;
-        height: 100%;
-      }
-
-      #graphChartContainer {
-        width: 100%;
-        height: 100%;
-      }
     </style>
   </head>
   <body>

--- a/public/example_templates/netjsonmap-animation.html
+++ b/public/example_templates/netjsonmap-animation.html
@@ -13,14 +13,39 @@
     <!-- theme can be easily customized via css -->
     <link href="../lib/css/netjsongraph-theme.css" rel="stylesheet" />
     <link href="../lib/css/netjsongraph.css" rel="stylesheet" />
+    <style>
+        html, body {
+        margin: 0;
+        padding: 0;
+        height: 100%;
+        width: 100%;
+      }
+
+      .netjsongraph-container {
+        position: absolute;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+      }
+
+      #graphChartContainer {
+        width: 100%;
+        height: 100%;
+      }
+    </style>
   </head>
   <body>
+    <div class="netjsongraph-container">
+     <div id="graphChartContainer"></div>
+   </div>
     <script>
       /*
           The demo is used to show hwo to set path animation.
           See `mapLinkConfig` below for details.
       */
       const graph = new NetJSONGraph("../assets/data/airplaneRouteMap.json", {
+        container: "#graphChartContainer",
         render: "map",
         echartsOption: {
           title: {
@@ -81,3 +106,4 @@
     </script>
   </body>
 </html>
+

--- a/public/example_templates/netjsonmap-animation.html
+++ b/public/example_templates/netjsonmap-animation.html
@@ -1,5 +1,5 @@
-<!DOCTYPE html>
-<html>
+<!doctype html>
+<html lang="en">
   <head>
     <title>netjsongraph.js: Dark Colors</title>
     <meta charset="utf-8" />
@@ -13,26 +13,28 @@
     <!-- theme can be easily customized via css -->
     <link href="../lib/css/netjsongraph-theme.css" rel="stylesheet" />
     <link href="../lib/css/netjsongraph.css" rel="stylesheet" />
-    <style>
-        html, body {
-        margin: 0;
-        padding: 0;
-        height: 100%;
-        width: 100%;
-      }
-    </style>
+    <link href="../assets/css/examples.css" rel="stylesheet" />
   </head>
   <body>
-    <div class="netjsongraph-container">
-     <div id="graphChartContainer"></div>
-   </div>
+    <div id="njg">
+      <div class="njg-relativePosition"></div>
+
+      <!-- Loading container -->
+      <div id="loadingContainer">
+        <div class="loadingElement">
+          <div class="loadingSprite"></div>
+          <div class="loadingTip">Loading...</div>
+        </div>
+      </div>
+    </div>
+
     <script>
       /*
-          The demo is used to show hwo to set path animation.
+          The demo is used to show how to set path animation.
           See `mapLinkConfig` below for details.
       */
       const graph = new NetJSONGraph("../assets/data/airplaneRouteMap.json", {
-        container: "#graphChartContainer",
+        el: "#njg",
         render: "map",
         echartsOption: {
           title: {
@@ -44,7 +46,6 @@
             },
           },
         },
-        // set map initial state.
         mapOptions: {
           center: [34.86, 112.5],
           zoom: 6,
@@ -78,7 +79,6 @@
             },
           },
         },
-        // Convert to internal json format
         prepareData: (data) => {
           data.nodes.map((node) => {
             node.label = node.name;
@@ -93,4 +93,3 @@
     </script>
   </body>
 </html>
-

--- a/public/example_templates/netjsonmap-appendData.html
+++ b/public/example_templates/netjsonmap-appendData.html
@@ -13,8 +13,32 @@
     <!-- theme can be easily customized via css -->
     <link href="../lib/css/netjsongraph-theme.css" rel="stylesheet" />
     <link href="../lib/css/netjsongraph.css" rel="stylesheet" />
+     <style>
+        html, body {
+        margin: 0;
+        padding: 0;
+        height: 100%;
+        width: 100%;
+      }
+
+      .netjsongraph-container {
+        position: absolute;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+      }
+
+      #graphChartContainer {
+        width: 100%;
+        height: 100%;
+      }
+    </style>
   </head>
   <body>
+     <div class="netjsongraph-container">
+     <div id="graphChartContainer"></div>
+   </div>
     <script type="text/javascript">
       /*
           The demo is used to show how to use the `JSONDataUpdate` function to update data.
@@ -29,6 +53,7 @@
         },
         map = new NetJSONGraph("../assets/data/netjsonAppendData/1.json", {
           render: "map",
+          container: "#graphChartContainer",
           // set map initial state.
           mapOptions: {
             center: [46.86764405052012, 19.675998687744144],

--- a/public/example_templates/netjsonmap-appendData.html
+++ b/public/example_templates/netjsonmap-appendData.html
@@ -20,19 +20,6 @@
         height: 100%;
         width: 100%;
       }
-
-      .netjsongraph-container {
-        position: absolute;
-        top: 0;
-        left: 0;
-        width: 100%;
-        height: 100%;
-      }
-
-      #graphChartContainer {
-        width: 100%;
-        height: 100%;
-      }
     </style>
   </head>
   <body>

--- a/public/example_templates/netjsonmap-appendData.html
+++ b/public/example_templates/netjsonmap-appendData.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
     <title>netjsongraph.js: basic example</title>
@@ -13,19 +13,21 @@
     <!-- theme can be easily customized via css -->
     <link href="../lib/css/netjsongraph-theme.css" rel="stylesheet" />
     <link href="../lib/css/netjsongraph.css" rel="stylesheet" />
-     <style>
-        html, body {
-        margin: 0;
-        padding: 0;
-        height: 100%;
-        width: 100%;
-      }
-    </style>
+    <link href="../assets/css/examples.css" rel="stylesheet" />
   </head>
   <body>
-     <div class="netjsongraph-container">
-     <div id="graphChartContainer"></div>
-   </div>
+    <div id="njg">
+      <div class="njg-relativePosition"></div>
+
+      <!-- Loading container -->
+      <div id="loadingContainer">
+        <div class="loadingElement">
+          <div class="loadingSprite"></div>
+          <div class="loadingTip">Loading...</div>
+        </div>
+      </div>
+    </div>
+
     <script type="text/javascript">
       /*
           The demo is used to show how to use the `JSONDataUpdate` function to update data.
@@ -40,7 +42,7 @@
         },
         map = new NetJSONGraph("../assets/data/netjsonAppendData/1.json", {
           render: "map",
-          container: "#graphChartContainer",
+          el: "#njg",
           // set map initial state.
           mapOptions: {
             center: [46.86764405052012, 19.675998687744144],

--- a/public/example_templates/netjsonmap-appendData2.html
+++ b/public/example_templates/netjsonmap-appendData2.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
     <title>netjsongraph.js: basic example</title>
@@ -13,23 +13,25 @@
     <!-- theme can be easily customized via css -->
     <link href="../lib/css/netjsongraph-theme.css" rel="stylesheet" />
     <link href="../lib/css/netjsongraph.css" rel="stylesheet" />
-     <style>
-        html, body {
-        margin: 0;
-        padding: 0;
-        height: 100%;
-        width: 100%;
-      }
-    </style>
+    <link href="../assets/css/examples.css" rel="stylesheet" />
   </head>
   <body>
-      <div class="netjsongraph-container">
-     <div id="graphChartContainer"></div>
-   </div>
+    <div id="njg">
+      <div class="njg-relativePosition"></div>
+
+      <!-- Loading container -->
+      <div id="loadingContainer">
+        <div class="loadingElement">
+          <div class="loadingSprite"></div>
+          <div class="loadingTip">Loading...</div>
+        </div>
+      </div>
+    </div>
+
     <script type="text/javascript">
       /*
           Using array files to append data step by step at start. 
-          Similiar to the first method, but easier.
+          Similar to the first method, but easier.
       */
       const map = new NetJSONGraph(
         [
@@ -39,8 +41,7 @@
         ],
         {
           render: "map",
-          container: "#graphChartContainer",
-          // set map initial state.
+          el: "#njg",
           mapOptions: {
             center: [46.86764405052012, 19.675998687744144],
             zoom: 2,
@@ -50,8 +51,6 @@
               },
             },
           },
-
-          // Convert to internal json format
           prepareData: (data) => {
             data.nodes.map((node) => {
               node.label = node.name;

--- a/public/example_templates/netjsonmap-appendData2.html
+++ b/public/example_templates/netjsonmap-appendData2.html
@@ -20,19 +20,6 @@
         height: 100%;
         width: 100%;
       }
-
-      .netjsongraph-container {
-        position: absolute;
-        top: 0;
-        left: 0;
-        width: 100%;
-        height: 100%;
-      }
-
-      #graphChartContainer {
-        width: 100%;
-        height: 100%;
-      }
     </style>
   </head>
   <body>

--- a/public/example_templates/netjsonmap-appendData2.html
+++ b/public/example_templates/netjsonmap-appendData2.html
@@ -13,8 +13,32 @@
     <!-- theme can be easily customized via css -->
     <link href="../lib/css/netjsongraph-theme.css" rel="stylesheet" />
     <link href="../lib/css/netjsongraph.css" rel="stylesheet" />
+     <style>
+        html, body {
+        margin: 0;
+        padding: 0;
+        height: 100%;
+        width: 100%;
+      }
+
+      .netjsongraph-container {
+        position: absolute;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+      }
+
+      #graphChartContainer {
+        width: 100%;
+        height: 100%;
+      }
+    </style>
   </head>
   <body>
+      <div class="netjsongraph-container">
+     <div id="graphChartContainer"></div>
+   </div>
     <script type="text/javascript">
       /*
           Using array files to append data step by step at start. 
@@ -28,6 +52,7 @@
         ],
         {
           render: "map",
+          container: "#graphChartContainer",
           // set map initial state.
           mapOptions: {
             center: [46.86764405052012, 19.675998687744144],

--- a/public/example_templates/netjsonmap-indoormap.html
+++ b/public/example_templates/netjsonmap-indoormap.html
@@ -22,19 +22,6 @@
         height: 100%;
         width: 100%;
       }
-
-      .netjsongraph-container {
-        position: absolute;
-        top: 0;
-        left: 0;
-        width: 100%;
-        height: 100%;
-      }
-
-      #graphChartContainer {
-        width: 100%;
-        height: 100%;
-      }
       
       .njg-tooltip {
         background: rgba(0, 0, 0, 0.75) !important;

--- a/public/example_templates/netjsonmap-indoormap.html
+++ b/public/example_templates/netjsonmap-indoormap.html
@@ -1,5 +1,5 @@
-<!DOCTYPE html>
-<html>
+<!doctype html>
+<html lang="en">
   <head>
     <title>Indoor map</title>
     <meta charset="utf-8" />
@@ -13,16 +13,9 @@
     <!-- theme can be easily customized via css -->
     <link href="../lib/css/netjsongraph-theme.css" rel="stylesheet" />
     <link href="../lib/css/netjsongraph.css" rel="stylesheet" />
-
+    <link href="../assets/css/examples.css" rel="stylesheet" />
     <link rel="preload" href="../assets/images/floorplan.png" as="image" />
     <style>
-      html, body {
-        margin: 0;
-        padding: 0;
-        height: 100%;
-        width: 100%;
-      }
-      
       .njg-tooltip {
         background: rgba(0, 0, 0, 0.75) !important;
         border: none !important;
@@ -36,15 +29,25 @@
       .njg-tooltip-value {
         color: #fff;
       }
+
       .njg-sideBar {
         background-color: #f7f7f7;
       }
     </style>
   </head>
   <body>
-    <div class="netjsongraph-container">
-     <div id="graphChartContainer"></div>
-   </div>
+    <div id="njg">
+      <div class="njg-relativePosition"></div>
+
+      <!-- Loading container -->
+      <div id="loadingContainer">
+        <div class="loadingElement">
+          <div class="loadingSprite"></div>
+          <div class="loadingTip">Loading...</div>
+        </div>
+      </div>
+    </div>
+
     <script>
       /*
           The demo is used to show how to set indoor map.
@@ -55,7 +58,7 @@
         "../assets/data/netjsonmap-indoormap.json",
         {
           render: "map",
-          container: "#graphChartContainer",
+          el: "#njg",
           // set map initial state.
           mapOptions: {
             center: [48.577, 18.539],

--- a/public/example_templates/netjsonmap-indoormap.html
+++ b/public/example_templates/netjsonmap-indoormap.html
@@ -16,6 +16,26 @@
 
     <link rel="preload" href="../assets/images/floorplan.png" as="image" />
     <style>
+      html, body {
+        margin: 0;
+        padding: 0;
+        height: 100%;
+        width: 100%;
+      }
+
+      .netjsongraph-container {
+        position: absolute;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+      }
+
+      #graphChartContainer {
+        width: 100%;
+        height: 100%;
+      }
+      
       .njg-tooltip {
         background: rgba(0, 0, 0, 0.75) !important;
         border: none !important;
@@ -35,6 +55,9 @@
     </style>
   </head>
   <body>
+    <div class="netjsongraph-container">
+     <div id="graphChartContainer"></div>
+   </div>
     <script>
       /*
           The demo is used to show how to set indoor map.
@@ -45,6 +68,7 @@
         "../assets/data/netjsonmap-indoormap.json",
         {
           render: "map",
+          container: "#graphChartContainer",
           // set map initial state.
           mapOptions: {
             center: [48.577, 18.539],

--- a/public/example_templates/netjsonmap-multipleTiles.html
+++ b/public/example_templates/netjsonmap-multipleTiles.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
     <title>netjsongraph.js: basic example</title>
@@ -13,30 +13,33 @@
     <!-- theme can be easily customized via css -->
     <link href="../lib/css/netjsongraph-theme.css" rel="stylesheet" />
     <link href="../lib/css/netjsongraph.css" rel="stylesheet" />
+    <link href="../assets/css/examples.css" rel="stylesheet" />
     <style type="text/css">
-      html, body {
-        margin: 0;
-        padding: 0;
-        height: 100%;
-        width: 100%;
-      }
-
       .leaflet-control-zoom {
         right: 5px;
       }
     </style>
   </head>
   <body>
-     <div class="netjsongraph-container">
-     <div id="graphChartContainer"></div>
-   </div>
+    <div id="njg">
+      <div class="njg-relativePosition"></div>
+
+      <!-- Loading container -->
+      <div id="loadingContainer">
+        <div class="loadingElement">
+          <div class="loadingSprite"></div>
+          <div class="loadingTip">Loading...</div>
+        </div>
+      </div>
+    </div>
+
     <script type="text/javascript">
       /*
-               The demo is used to show the multiple tiles render.
-           */
+        The demo is used to show the multiple tiles render.
+      */
       const map = new NetJSONGraph("../assets/data/netjsonmap.json", {
         render: "map",
-        container: "#graphChartContainer",
+        el: "#njg",
         // set multiple tiles config, can change them dynamically.
         mapTileConfig: [
           {
@@ -90,4 +93,3 @@
     </script>
   </body>
 </html>
-

--- a/public/example_templates/netjsonmap-multipleTiles.html
+++ b/public/example_templates/netjsonmap-multipleTiles.html
@@ -21,19 +21,6 @@
         width: 100%;
       }
 
-      .netjsongraph-container {
-        position: absolute;
-        top: 0;
-        left: 0;
-        width: 100%;
-        height: 100%;
-      }
-
-      #graphChartContainer {
-        width: 100%;
-        height: 100%;
-      }
-
       .leaflet-control-zoom {
         right: 5px;
       }

--- a/public/example_templates/netjsonmap-multipleTiles.html
+++ b/public/example_templates/netjsonmap-multipleTiles.html
@@ -14,18 +14,42 @@
     <link href="../lib/css/netjsongraph-theme.css" rel="stylesheet" />
     <link href="../lib/css/netjsongraph.css" rel="stylesheet" />
     <style type="text/css">
+      html, body {
+        margin: 0;
+        padding: 0;
+        height: 100%;
+        width: 100%;
+      }
+
+      .netjsongraph-container {
+        position: absolute;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+      }
+
+      #graphChartContainer {
+        width: 100%;
+        height: 100%;
+      }
+
       .leaflet-control-zoom {
         right: 5px;
       }
     </style>
   </head>
   <body>
+     <div class="netjsongraph-container">
+     <div id="graphChartContainer"></div>
+   </div>
     <script type="text/javascript">
       /*
                The demo is used to show the multiple tiles render.
            */
       const map = new NetJSONGraph("../assets/data/netjsonmap.json", {
         render: "map",
+        container: "#graphChartContainer",
         // set multiple tiles config, can change them dynamically.
         mapTileConfig: [
           {
@@ -79,3 +103,4 @@
     </script>
   </body>
 </html>
+

--- a/public/example_templates/netjsonmap-nodeTiles.html
+++ b/public/example_templates/netjsonmap-nodeTiles.html
@@ -13,8 +13,34 @@
     <!-- theme can be easily customized via css -->
     <link href="../lib/css/netjsongraph-theme.css" rel="stylesheet" />
     <link href="../lib/css/netjsongraph.css" rel="stylesheet" />
+    <style>
+      html, body {
+        margin: 0;
+        padding: 0;
+        height: 100%;
+        width: 100%;
+      }
+
+      .netjsongraph-container {
+        position: absolute;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+      }
+
+      #graphChartContainer {
+        width: 100%;
+        height: 100%;
+      }
+      
+    </style>
   </head>
   <body>
+    <div class="netjsongraph-container">
+      <div id="graphChartContainer"></div>
+    </div>
+
     <script type="text/javascript">
       /*
           The demo is used to show how to use the `JSONDataUpdate` function to update data.
@@ -30,6 +56,7 @@
         },
         map = new NetJSONGraph("../assets/data/netjsonNodeTiles/1.json", {
           render: "map",
+          container: "#graphChartContainer",
           // set map initial state.
           mapOptions: {
             center: [46.86764405052012, 19.675998687744144],

--- a/public/example_templates/netjsonmap-nodeTiles.html
+++ b/public/example_templates/netjsonmap-nodeTiles.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
     <title>netjsongraph.js: basic example</title>
@@ -13,19 +13,19 @@
     <!-- theme can be easily customized via css -->
     <link href="../lib/css/netjsongraph-theme.css" rel="stylesheet" />
     <link href="../lib/css/netjsongraph.css" rel="stylesheet" />
-    <style>
-      html, body {
-        margin: 0;
-        padding: 0;
-        height: 100%;
-        width: 100%;
-      }
-      
-    </style>
+    <link href="../assets/css/examples.css" rel="stylesheet" />
   </head>
   <body>
-    <div class="netjsongraph-container">
-      <div id="graphChartContainer"></div>
+    <div id="njg">
+      <div class="njg-relativePosition"></div>
+
+      <!-- Loading container -->
+      <div id="loadingContainer">
+        <div class="loadingElement">
+          <div class="loadingSprite"></div>
+          <div class="loadingTip">Loading...</div>
+        </div>
+      </div>
     </div>
 
     <script type="text/javascript">
@@ -43,7 +43,7 @@
         },
         map = new NetJSONGraph("../assets/data/netjsonNodeTiles/1.json", {
           render: "map",
-          container: "#graphChartContainer",
+          el: "#njg",
           // set map initial state.
           mapOptions: {
             center: [46.86764405052012, 19.675998687744144],

--- a/public/example_templates/netjsonmap-nodeTiles.html
+++ b/public/example_templates/netjsonmap-nodeTiles.html
@@ -20,19 +20,6 @@
         height: 100%;
         width: 100%;
       }
-
-      .netjsongraph-container {
-        position: absolute;
-        top: 0;
-        left: 0;
-        width: 100%;
-        height: 100%;
-      }
-
-      #graphChartContainer {
-        width: 100%;
-        height: 100%;
-      }
       
     </style>
   </head>

--- a/public/example_templates/netjsonmap-plugins.html
+++ b/public/example_templates/netjsonmap-plugins.html
@@ -22,19 +22,6 @@
         height: 100%;
         width: 100%;
       }
-
-      .netjsongraph-container {
-        position: absolute;
-        top: 0;
-        left: 0;
-        width: 100%;
-        height: 100%;
-      }
-
-      #graphChartContainer {
-        width: 100%;
-        height: 100%;
-      }
       
       .leaflet-control-zoom {
         top: 55px;

--- a/public/example_templates/netjsonmap-plugins.html
+++ b/public/example_templates/netjsonmap-plugins.html
@@ -16,6 +16,26 @@
     <link href="../lib/css/netjsongraph-theme.css" rel="stylesheet" />
     <link href="../lib/css/netjsongraph.css" rel="stylesheet" />
     <style type="text/css">
+      html, body {
+        margin: 0;
+        padding: 0;
+        height: 100%;
+        width: 100%;
+      }
+
+      .netjsongraph-container {
+        position: absolute;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+      }
+
+      #graphChartContainer {
+        width: 100%;
+        height: 100%;
+      }
+      
       .leaflet-control-zoom {
         top: 55px;
       }
@@ -23,6 +43,10 @@
   </head>
 
   <body>
+    <div class="netjsongraph-container">
+      <div id="graphChartContainer"></div>
+    </div>
+
     <script type="text/javascript" src="../lib/js/leaflet-draw.js"></script>
     <script type="text/javascript" src="../lib/js/leaflet-measure.js"></script>
     <script type="module">
@@ -33,6 +57,7 @@
       */
       const graph = new NetJSONGraph("../assets/data/netjsonmap.json", {
         render: "map",
+        container: "#graphChartContainer",
         // set map initial state.
         mapOptions: {
           center: [46.86764405052012, 19.675998687744144],
@@ -127,3 +152,4 @@
     </script>
   </body>
 </html>
+

--- a/public/example_templates/netjsonmap-plugins.html
+++ b/public/example_templates/netjsonmap-plugins.html
@@ -1,5 +1,5 @@
-<!DOCTYPE html>
-<html>
+<!doctype html>
+<html lang="en">
   <head>
     <title>netjsongraph.js: Leaflet plugins</title>
     <meta charset="utf-8" />
@@ -15,14 +15,8 @@
     <!-- theme can be easily customized via css -->
     <link href="../lib/css/netjsongraph-theme.css" rel="stylesheet" />
     <link href="../lib/css/netjsongraph.css" rel="stylesheet" />
+    <link href="../assets/css/examples.css" rel="stylesheet" />
     <style type="text/css">
-      html, body {
-        margin: 0;
-        padding: 0;
-        height: 100%;
-        width: 100%;
-      }
-      
       .leaflet-control-zoom {
         top: 55px;
       }
@@ -30,8 +24,16 @@
   </head>
 
   <body>
-    <div class="netjsongraph-container">
-      <div id="graphChartContainer"></div>
+    <div id="njg">
+      <div class="njg-relativePosition"></div>
+
+      <!-- Loading container -->
+      <div id="loadingContainer">
+        <div class="loadingElement">
+          <div class="loadingSprite"></div>
+          <div class="loadingTip">Loading...</div>
+        </div>
+      </div>
     </div>
 
     <script type="text/javascript" src="../lib/js/leaflet-draw.js"></script>
@@ -44,7 +46,7 @@
       */
       const graph = new NetJSONGraph("../assets/data/netjsonmap.json", {
         render: "map",
-        container: "#graphChartContainer",
+        el: "#njg",
         // set map initial state.
         mapOptions: {
           center: [46.86764405052012, 19.675998687744144],
@@ -139,4 +141,3 @@
     </script>
   </body>
 </html>
-

--- a/public/example_templates/netjsonmap.html
+++ b/public/example_templates/netjsonmap.html
@@ -4,17 +4,16 @@
     <title>netjsongraph.js: basic example</title>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.8.0/dist/leaflet.css" integrity="sha512-hoalWLoI8r4UszCkZ5kL8vayOGVae1oxXe/2A4AO6J9+580uKHDO3JdHb7NzwwzK5xr/Fs0W40kiNHxM9vyTtQ==" crossorigin="" />
+    <link
+      rel="stylesheet"
+      href="https://unpkg.com/leaflet@1.8.0/dist/leaflet.css"
+      integrity="sha512-hoalWLoI8r4UszCkZ5kL8vayOGVae1oxXe/2A4AO6J9+580uKHDO3JdHb7NzwwzK5xr/Fs0W40kiNHxM9vyTtQ=="
+      crossorigin=""
+    />
     <link href="../lib/css/netjsongraph-theme.css" rel="stylesheet" />
     <link href="../lib/css/netjsongraph.css" rel="stylesheet" />
+    <link href="../assets/css/examples.css" rel="stylesheet" />
     <style>
-      html, body {
-        margin: 0;
-        padding: 0;
-        height: 100%;
-        width: 100%;
-      }
-
       #legend h4 {
         margin: 10px 0;
         text-align: center;
@@ -30,7 +29,7 @@
         background: #fbfbfb;
         border-radius: 8px;
         color: #000;
-        font-family: Arial, sans-serif;
+        font-family: "iconfont", Arial, sans-serif;
         font-size: 14px;
         z-index: 1000;
         user-select: text;
@@ -67,14 +66,22 @@
     </style>
   </head>
   <body>
-    <div class="netjsongraph-container">
-      <div id="graphChartContainer"></div>
+    <div id="njg">
+      <div class="njg-relativePosition"></div>
+
+      <!-- Loading container -->
+      <div id="loadingContainer">
+        <div class="loadingElement">
+          <div class="loadingSprite"></div>
+          <div class="loadingTip">Loading...</div>
+        </div>
+      </div>
     </div>
 
     <script type="text/javascript">
       const map = new NetJSONGraph("../assets/data/netjsonmap.json", {
         render: "map",
-        container: "#graphChartContainer",
+        el: "#njg",
         mapOptions: {
           center: [46.86764405052012, 19.675998687744144],
           zoom: 5,

--- a/public/example_templates/netjsonmap.html
+++ b/public/example_templates/netjsonmap.html
@@ -1,19 +1,33 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
     <title>netjsongraph.js: basic example</title>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <link
-      rel="stylesheet"
-      href="https://unpkg.com/leaflet@1.8.0/dist/leaflet.css"
-      integrity="sha512-hoalWLoI8r4UszCkZ5kL8vayOGVae1oxXe/2A4AO6J9+580uKHDO3JdHb7NzwwzK5xr/Fs0W40kiNHxM9vyTtQ=="
-      crossorigin=""
-    />
-    <!-- theme can be easily customized via css -->
+    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.8.0/dist/leaflet.css" integrity="sha512-hoalWLoI8r4UszCkZ5kL8vayOGVae1oxXe/2A4AO6J9+580uKHDO3JdHb7NzwwzK5xr/Fs0W40kiNHxM9vyTtQ==" crossorigin="" />
     <link href="../lib/css/netjsongraph-theme.css" rel="stylesheet" />
     <link href="../lib/css/netjsongraph.css" rel="stylesheet" />
-    <style type="text/css">
+    <style>
+      html, body {
+        margin: 0;
+        padding: 0;
+        height: 100%;
+        width: 100%;
+      }
+
+      .netjsongraph-container {
+        position: absolute;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+      }
+
+      #graphChartContainer {
+        width: 100%;
+        height: 100%;
+      }
+
       #legend h4 {
         margin: 10px 0;
         text-align: center;
@@ -30,7 +44,6 @@
         border-radius: 8px;
         color: #000;
         font-family: Arial, sans-serif;
-        font-family: sans-serif;
         font-size: 14px;
         z-index: 1000;
         user-select: text;
@@ -59,7 +72,6 @@
         color: red;
         margin-right: 10px;
       }
-
       @media only screen and (max-width: 850px) {
         #legend {
           right: 15px;
@@ -68,10 +80,14 @@
     </style>
   </head>
   <body>
+    <div class="netjsongraph-container">
+      <div id="graphChartContainer"></div>
+    </div>
+
     <script type="text/javascript">
       const map = new NetJSONGraph("../assets/data/netjsonmap.json", {
         render: "map",
-        // set map initial state.
+        container: "#graphChartContainer",
         mapOptions: {
           center: [46.86764405052012, 19.675998687744144],
           zoom: 5,
@@ -96,7 +112,6 @@
             },
           },
         ],
-        // Convert to internal json format
         prepareData: (data) => {
           data.nodes.map((node) => {
             node.label = node.name;
@@ -117,15 +132,13 @@
       const createLegend = (key, name) => {
         const legendItem = document.createElement("p");
         const legendIcon = document.createElement("span");
-
         legendIcon.setAttribute("class", name);
-
         legends.appendChild(legendItem);
         legendItem.appendChild(legendIcon);
-
         legendItem.innerHTML += key;
         return legendItem;
       };
+
       const legends = document.createElement("div");
       const legendsHeader = document.createElement("h4");
       legends.setAttribute("id", "legend");

--- a/public/example_templates/netjsonmap.html
+++ b/public/example_templates/netjsonmap.html
@@ -15,19 +15,6 @@
         width: 100%;
       }
 
-      .netjsongraph-container {
-        position: absolute;
-        top: 0;
-        left: 0;
-        width: 100%;
-        height: 100%;
-      }
-
-      #graphChartContainer {
-        width: 100%;
-        height: 100%;
-      }
-
       #legend h4 {
         margin: 10px 0;
         text-align: center;

--- a/public/example_templates/netjsonmap.html
+++ b/public/example_templates/netjsonmap.html
@@ -1,4 +1,4 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
   <head>
     <title>netjsongraph.js: basic example</title>
@@ -10,10 +10,11 @@
       integrity="sha512-hoalWLoI8r4UszCkZ5kL8vayOGVae1oxXe/2A4AO6J9+580uKHDO3JdHb7NzwwzK5xr/Fs0W40kiNHxM9vyTtQ=="
       crossorigin=""
     />
+    <!-- theme can be easily customized via css -->
     <link href="../lib/css/netjsongraph-theme.css" rel="stylesheet" />
     <link href="../lib/css/netjsongraph.css" rel="stylesheet" />
     <link href="../assets/css/examples.css" rel="stylesheet" />
-    <style>
+    <style type="text/css">
       #legend h4 {
         margin: 10px 0;
         text-align: center;
@@ -29,7 +30,8 @@
         background: #fbfbfb;
         border-radius: 8px;
         color: #000;
-        font-family: "iconfont", Arial, sans-serif;
+        font-family: Arial, sans-serif;
+        font-family: sans-serif;
         font-size: 14px;
         z-index: 1000;
         user-select: text;
@@ -58,6 +60,7 @@
         color: red;
         margin-right: 10px;
       }
+
       @media only screen and (max-width: 850px) {
         #legend {
           right: 15px;
@@ -68,6 +71,7 @@
   <body>
     <div id="njg">
       <div class="njg-relativePosition"></div>
+    </div>
 
       <!-- Loading container -->
       <div id="loadingContainer">
@@ -76,12 +80,11 @@
           <div class="loadingTip">Loading...</div>
         </div>
       </div>
-    </div>
-
     <script type="text/javascript">
       const map = new NetJSONGraph("../assets/data/netjsonmap.json", {
         render: "map",
         el: "#njg",
+        // set map initial state.
         mapOptions: {
           center: [46.86764405052012, 19.675998687744144],
           zoom: 5,
@@ -106,6 +109,7 @@
             },
           },
         ],
+        // Convert to internal json format
         prepareData: (data) => {
           data.nodes.map((node) => {
             node.label = node.name;
@@ -126,13 +130,15 @@
       const createLegend = (key, name) => {
         const legendItem = document.createElement("p");
         const legendIcon = document.createElement("span");
+
         legendIcon.setAttribute("class", name);
+
         legends.appendChild(legendItem);
         legendItem.appendChild(legendIcon);
+
         legendItem.innerHTML += key;
         return legendItem;
       };
-
       const legends = document.createElement("div");
       const legendsHeader = document.createElement("h4");
       legends.setAttribute("id", "legend");

--- a/public/example_templates/njg-geojson.html
+++ b/public/example_templates/njg-geojson.html
@@ -20,19 +20,6 @@
         height: 100%;
         width: 100%;
       }
-
-      .netjsongraph-container {
-        position: absolute;
-        top: 0;
-        left: 0;
-        width: 100%;
-        height: 100%;
-      }
-
-      #graphChartContainer {
-        width: 100%;
-        height: 100%;
-      }
     </style>
   </head>
   <body>

--- a/public/example_templates/njg-geojson.html
+++ b/public/example_templates/njg-geojson.html
@@ -13,11 +13,37 @@
     <!-- theme can be easily customized via css -->
     <link href="../lib/css/netjsongraph-theme.css" rel="stylesheet" />
     <link href="../lib/css/netjsongraph.css" rel="stylesheet" />
+    <style>
+      html, body {
+        margin: 0;
+        padding: 0;
+        height: 100%;
+        width: 100%;
+      }
+
+      .netjsongraph-container {
+        position: absolute;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+      }
+
+      #graphChartContainer {
+        width: 100%;
+        height: 100%;
+      }
+    </style>
   </head>
   <body>
+    <div class="netjsongraph-container">
+      <div id="graphChartContainer"></div>
+    </div>
+
     <script type="text/javascript">
       const map = new NetJSONGraph("../assets/data/geojson-sample.json", {
         render: "map",
+        container: "#graphChartContainer",
         // set map initial state.
         mapOptions: {
           center: [46.86764405052012, 19.675998687744144],

--- a/public/example_templates/njg-geojson.html
+++ b/public/example_templates/njg-geojson.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
     <title>GeoJSON Example</title>
@@ -13,25 +13,25 @@
     <!-- theme can be easily customized via css -->
     <link href="../lib/css/netjsongraph-theme.css" rel="stylesheet" />
     <link href="../lib/css/netjsongraph.css" rel="stylesheet" />
-    <style>
-      html, body {
-        margin: 0;
-        padding: 0;
-        height: 100%;
-        width: 100%;
-      }
-    </style>
+    <link href="../assets/css/examples.css" rel="stylesheet" />
   </head>
   <body>
-    <div class="netjsongraph-container">
-      <div id="graphChartContainer"></div>
+    <div id="njg">
+      <div class="njg-relativePosition"></div>
+
+      <!-- Loading container -->
+      <div id="loadingContainer">
+        <div class="loadingElement">
+          <div class="loadingSprite"></div>
+          <div class="loadingTip">Loading...</div>
+        </div>
+      </div>
     </div>
 
     <script type="text/javascript">
       const map = new NetJSONGraph("../assets/data/geojson-sample.json", {
         render: "map",
-        container: "#graphChartContainer",
-        // set map initial state.
+        el: "#njg",
         mapOptions: {
           center: [46.86764405052012, 19.675998687744144],
           zoom: 5,

--- a/src/css/netjsongraph.css
+++ b/src/css/netjsongraph.css
@@ -10,7 +10,6 @@ body {
   width: 100%;
   height: 100%;
   overflow: hidden;
-  font-family: Arial, sans-serif;
   font-family: sans-serif;
   font-size: 14px;
 }
@@ -20,8 +19,8 @@ h3 {
   font-size: 1.17em;
   margin-block-start: 1em;
   margin-block-end: 1em;
-  margin-inline-start: 0px;
-  margin-inline-end: 0px;
+  margin-inline-start: 0;
+  margin-inline-end: 0;
   font-weight: bold;
 }
 
@@ -29,8 +28,8 @@ p {
   display: block;
   margin-block-start: 1em;
   margin-block-end: 1em;
-  margin-inline-start: 0px;
-  margin-inline-end: 0px;
+  margin-inline-start: 0;
+  margin-inline-end: 0;
 }
 
 .njg-relativePosition {
@@ -183,7 +182,7 @@ p {
 }
 
 .iconfont {
-  font-family: "iconfont" !important;
+  font-family: "iconfont", serif !important;
   font-size: 30px;
   font-style: normal;
   -webkit-font-smoothing: antialiased;
@@ -191,7 +190,7 @@ p {
 }
 
 .iconfont {
-  font-family: "iconfont" !important;
+  font-family: "iconfont", serif !important;
   font-size: 30px;
   font-style: normal;
   cursor: pointer;
@@ -286,7 +285,7 @@ p {
   flex-direction: column;
   align-items: center;
   justify-content: space-between;
-  padding: 20px 0px;
+  padding: 20px 0;
 }
 
 .njg-metaData,

--- a/src/css/netjsongraph.css
+++ b/src/css/netjsongraph.css
@@ -1,28 +1,15 @@
-.netjsongraph-container {
+#njg {
+  width: 100%;
+  height: 100%;
   position: absolute;
   top: 0;
   left: 0;
-  width: 100%;
-  height: 100%;
-  margin: 0;
-  padding: 0;
-  box-sizing: border-box;
-  width: 100%;
-  height: 100%;
-  margin: 0;
-  padding: 0;
-  box-sizing: border-box;
-}
-
-#graphChartContainer {
-  width: 100%;
-  height: 100%;
-  font-family: Arial, sans-serif;
+  font-family: sans-serif;
   font-size: 14px;
   overflow: hidden;
 }
 
-h3 {
+#njg h3 {
   display: block;
   font-size: 1.17em;
   margin-block-start: 1em;
@@ -32,7 +19,7 @@ h3 {
   font-weight: bold;
 }
 
-p {
+#njg p {
   display: block;
   margin-block-start: 1em;
   margin-block-end: 1em;
@@ -46,7 +33,7 @@ p {
   right: 0;
 }
 
-#graphChartContainer {
+#njg {
   width: 100%;
   height: 100%;
   overflow: hidden;
@@ -72,6 +59,7 @@ p {
   height: 100px;
   text-align: center;
 }
+
 .loadingSprite {
   margin: 0 auto;
   width: 40px;
@@ -88,28 +76,28 @@ p {
 
 .leaflet-control-zoom {
   top: 5px;
-  border: 0 !important;
+  border: 0;
 }
 
 .leaflet-control-zoom-in {
-  border-top-left-radius: 5px !important;
-  border-top-right-radius: 5px !important;
+  border-top-left-radius: 5px;
+  border-top-right-radius: 5px;
 }
 
 .leaflet-control-zoom-out {
-  border-bottom-left-radius: 5px !important;
-  border-bottom-right-radius: 5px !important;
+  border-bottom-left-radius: 5px;
+  border-bottom-right-radius: 5px;
 }
 
 .leaflet-control-layers {
-  border: none !important;
-  right: 3px !important;
+  border: none;
+  right: 3px;
 }
 
 .leaflet-control-layers-toggle {
-  height: 35px !important;
-  width: 35px !important;
-  background-size: 20px 20px !important;
+  height: 35px;
+  width: 35px;
+  background-size: 20px 20px;
 }
 
 #njg-indoorImgInput {
@@ -139,6 +127,7 @@ p {
   z-index: 1;
   cursor: pointer;
 }
+
 .switch-wrap label {
   display: inline-block;
   width: 60px;
@@ -154,6 +143,7 @@ p {
   position: relative;
   margin: 0 5px;
 }
+
 .switch-wrap label::before {
   content: "";
   position: absolute;
@@ -168,6 +158,7 @@ p {
 .switch-wrap input[type="checkbox"]:checked + label:before {
   transform: translateX(34px);
 }
+
 .njg-date {
   position: absolute;
   right: 20px;
@@ -175,38 +166,16 @@ p {
   z-index: 1;
 }
 
-@font-face {
-  font-family: "iconfont";
-  src: url("iconfont.eot?t=1554537125905"); /* IE9 */
-  src:
-    url("iconfont.eot?t=1554537125905#iefix") format("embedded-opentype"),
-    /* IE6-IE8 */
-      url("data:application/x-font-woff2;charset=utf-8;base64,d09GMgABAAAAAALUAAsAAAAABoQAAAKGAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHEIGVgCCcAqBEIEuATYCJAMICwYABCAFhG0HLRvRBcguoRzbUaRIzQw73HPLf7QTlBZ2D/IcIqjWsJ69DaJClJGADlmhijCpCBUFUgELGaHg/4X/3P9am73DJNR5j3rniUuYJZWV+Sv+d1DrkBIhatJGhdBMSonZDe5mGYwm3qYronsgVPRfaegmrtP2H/dOG0u7QOYDymWugZ+6AOOtgY41KLISyrjHcAqrwkXmf5xApQ4ZykLfyDjUyWhcIC5sU4W6gk+W5WS5UNqwNItbJcrTdQrcRN+Pf0pRR1JSoLK1814DOr6Kp7H/u+8oQPETcHUJCowBmdhqjK1IC5mSVhmr0gOOVRx81QcGcVStkP86KqwGbcB7Jr4neNTCBDL0jgKLk9zkWpoZV083Lk3aU+QEjguciAOc6rXwcih7x22pDzGBTA58/6i7Kf9X4OyAnUy7Lf+SwMWzebmVOkI2slFyqJCVI4UN6dZul2us9Ehnd6SGqrxTzKCfFY+pPRQE/8sGl1onvrwqg8/d6kiTDXOA8kvZg7+MP7AmW0JSppPz0J6M5rIkVFpOv8jV6GWqquX5LKG8wJchKdMOhXJ96IwfgxJVxqFUuWmoNKp/dZUmUlrkCow4YRDqnUNS6x4K9R7RGf8MJVq9Qqn6SEOlnWjasspA2A3zklQmA7UNtPUwEK6RG+LiUTJXPFXmhRF1kmRiB7GYK5ST/RSQXGJGsmqWmAUKGfrYx04jzwsxkqFDOucs5qiSz4umN+X00IcG8ySiYsSANBuQTRcKiKAxa6h8fhQxrfCoZAeiyTqJSAm7f1SUUxiA7pcFgxCP8kpilamEMQEJUsiH+tgg4vGEUNQ8yEF0LMeaEIlU5Hk9MVSW217h/7pNUInUKXhVobhUAwAAAA==")
-      format("woff2"),
-    url("iconfont.woff?t=1554537125905") format("woff"),
-    url("iconfont.ttf?t=1554537125905") format("truetype"),
-    /* chrome, firefox, opera, Safari, Android, iOS 4.2+ */
-      url("iconfont.svg?t=1554537125905#iconfont") format("svg"); /* iOS 4.1- */
-}
-
-.iconfont {
+.njg-iconfont {
   font-family: "iconfont", serif !important;
   font-size: 30px;
   font-style: normal;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
-}
-
-.iconfont {
-  font-family: "iconfont", serif !important;
-  font-size: 30px;
-  font-style: normal;
   cursor: pointer;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
 }
 
-.icon-eye:before {
+.njg-icon-eye:before {
   content: "\e63f";
   position: relative;
   top: -2px;
@@ -220,6 +189,7 @@ p {
   border-radius: 5px;
   border: 0;
 }
+
 .njg-controls {
   display: flex;
   justify-content: space-between;
@@ -230,14 +200,17 @@ p {
   z-index: 999;
   background-color: inherit;
 }
+
 .njg-searchInput {
   width: 250px;
   height: 20px;
 }
+
 .njg-searchBtn {
   padding: 5px 10px;
   margin-left: 10px;
 }
+
 .njg-searchContainer {
   position: absolute;
   top: 10px;
@@ -350,6 +323,7 @@ p {
   text-transform: capitalize;
   font-weight: 600;
 }
+
 .njg-tooltip-value {
   display: inline-flex;
   align-items: center;

--- a/src/css/netjsongraph.css
+++ b/src/css/netjsongraph.css
@@ -1,18 +1,22 @@
-* {
+.netjsongraph-container {
   margin: 0;
   padding: 0;
-  outline: none;
   box-sizing: border-box;
 }
 
-html,
-body {
+.netjsongraph-container html,
+.netjsongraph-container body {
   width: 100%;
   height: 100%;
   overflow: hidden;
+<<<<<<< HEAD
   font-family: sans-serif;
+=======
+  font-family: Arial, sans-serif;
+>>>>>>> 47dabc9 (Fixing global css issue)
   font-size: 14px;
 }
+
 
 h3 {
   display: block;

--- a/src/css/netjsongraph.css
+++ b/src/css/netjsongraph.css
@@ -1,22 +1,13 @@
 .netjsongraph-container {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
   margin: 0;
   padding: 0;
   box-sizing: border-box;
 }
-
-.netjsongraph-container html,
-.netjsongraph-container body {
-  width: 100%;
-  height: 100%;
-  overflow: hidden;
-<<<<<<< HEAD
-  font-family: sans-serif;
-=======
-  font-family: Arial, sans-serif;
->>>>>>> 47dabc9 (Fixing global css issue)
-  font-size: 14px;
-}
-
 
 h3 {
   display: block;

--- a/src/js/netjsongraph.render.js
+++ b/src/js/netjsongraph.render.js
@@ -1,19 +1,35 @@
-import * as echarts from "echarts/lib/echarts";
-import "echarts/lib/chart/graph";
-import "echarts/lib/chart/effectScatter";
-import "echarts/lib/chart/lines";
-import "echarts/lib/component/tooltip";
-import "echarts/lib/component/title";
-import "echarts/lib/component/toolbox";
-import "echarts/lib/component/legend";
+import * as echarts from "echarts/core";
+import {
+  GraphChart,
+  EffectScatterChart,
+  LinesChart,
+  ScatterChart,
+} from "echarts/charts";
+import {
+  TooltipComponent,
+  TitleComponent,
+  ToolboxComponent,
+  LegendComponent,
+} from "echarts/components";
+import {SVGRenderer} from "echarts/renderers";
 import L from "leaflet/dist/leaflet";
 import "leaflet.markercluster";
 import "leaflet.markercluster/dist/MarkerCluster.css";
 import "leaflet.markercluster/dist/MarkerCluster.Default.css";
 
-import "zrender/lib/svg/svg";
+import "echarts-gl";
 
-import "../../lib/js/echarts-gl.min";
+echarts.use([
+  GraphChart,
+  EffectScatterChart,
+  LinesChart,
+  TooltipComponent,
+  TitleComponent,
+  ToolboxComponent,
+  LegendComponent,
+  SVGRenderer,
+  ScatterChart,
+]);
 
 class NetJSONGraphRender {
   /**
@@ -56,7 +72,7 @@ class NetJSONGraphRender {
           },
           padding: [5, 12],
           textStyle: {
-            lineHeight: 5,
+            lineHeight: 20,
           },
           renderMode: "html",
           className: "njg-tooltip",

--- a/test/browser.test.utils.js
+++ b/test/browser.test.utils.js
@@ -19,7 +19,9 @@ const url = "http://0.0.0.0:8080";
 export const getDriver = async () => {
   try {
     const options = new chrome.Options();
-    options.addArguments("--headless");
+    options.addArguments("--headless=new");
+    options.addArguments("--disable-dev-shm-usage");
+    options.addArguments("--no-sandbox");
     options.addArguments("--remote-debugging-pipe");
     return new Builder().forBrowser("chrome").setChromeOptions(options).build();
   } catch (err) {

--- a/test/browser.test.utils.js
+++ b/test/browser.test.utils.js
@@ -20,12 +20,7 @@ export const getDriver = async () => {
   try {
     const options = new chrome.Options();
     options.addArguments("--headless");
-    options.addArguments("--no-sandbox");
-    options.addArguments("--disable-dev-shm-usage");
-    options.addArguments("--disable-gpu");
-    options.addArguments("--disable-extensions");
-    options.addArguments("--disable-infobars");
-    options.addArguments("--remote-debugging-port=9222");
+    options.addArguments("--remote-debugging-pipe");
     return new Builder().forBrowser("chrome").setChromeOptions(options).build();
   } catch (err) {
     console.error("Failed to initialize driver:", err);

--- a/test/browser.test.utils.js
+++ b/test/browser.test.utils.js
@@ -20,6 +20,9 @@ export const getDriver = async () => {
   try {
     const options = new chrome.Options();
     options.addArguments("--headless");
+    options.addArguments("--no-sandbox");
+    options.addArguments("--disable-dev-shm-usage");
+    options.addArguments("--disable-gpu");
     options.addArguments("--remote-debugging-port=9222");
     return new Builder().forBrowser("chrome").setChromeOptions(options).build();
   } catch (err) {

--- a/test/browser.test.utils.js
+++ b/test/browser.test.utils.js
@@ -1,0 +1,134 @@
+import {Builder, By, until} from "selenium-webdriver";
+import chrome from "selenium-webdriver/chrome";
+import netJsonMap from "../public/assets/data/netjsonmap.json";
+import netJsonMultipleInterfaces from "../public/assets/data/netjson-multipleInterfaces.json";
+import netJsonGraphFoldNodes from "../public/assets/data/netjsongraph-foldNodes.json";
+import netJsonMapIndoorMap from "../public/assets/data/netjsonmap-indoormap.json";
+import netJsonGraphGraphGL from "../public/assets/data/netjsongraph-graphGL.json";
+import netJsonElementsLegend from "../public/assets/data/netjson-elementsLegend.json";
+import netJsonGraphMultipleLinks from "../public/assets/data/netjsongraph-multipleLinks.json";
+import airplaneRouteMap from "../public/assets/data/airplaneRouteMap.json";
+import geoJsonSample from "../public/assets/data/geojson-sample.json";
+import netJsonNodeTiles1 from "../public/assets/data/netjsonNodeTiles/1.json";
+import netJsonAppendData1 from "../public/assets/data/netjsonAppendData/1.json";
+import netJsonAppendData2 from "../public/assets/data/netjsonAppendData/2.json";
+import netJsonAppendData3 from "../public/assets/data/netjsonAppendData/3.json";
+
+const url = "http://0.0.0.0:8080";
+
+export const getDriver = async () => {
+  try {
+    const options = new chrome.Options();
+    options.addArguments("--headless");
+    options.addArguments("--remote-debugging-port=9222");
+    return new Builder().forBrowser("chrome").setChromeOptions(options).build();
+  } catch (err) {
+    console.error("Failed to initialize driver:", err);
+    throw err;
+  }
+};
+
+export const urls = {
+  basicUsage: `${url}/examples/netjsongraph.html`,
+  geographicMap: `${url}/examples/netjsonmap.html`,
+};
+
+export const getElementByCss = async (driver, css, waitTime = 1000) => {
+  try {
+    return await driver.wait(until.elementLocated(By.css(css)), waitTime);
+  } catch (err) {
+    console.error("Error finding element:", css, err);
+    return null;
+  }
+};
+
+export const getElementsByCss = async (driver, css, waitTime = 1000) => {
+  try {
+    return await driver.wait(until.elementsLocated(By.css(css)), waitTime);
+  } catch (err) {
+    console.error(`Error finding elements: ${css}`, err);
+    return [];
+  }
+};
+
+export const getRenderedNodesAndLinksCount = async (driver) => {
+  try {
+    const nodes = await driver.executeScript(`
+      return document.querySelector('.njg-metaDataItems:nth-child(5) .njg-valueLabel').textContent;
+    `);
+
+    const links = await driver.executeScript(`
+      return document.querySelector('.njg-metaDataItems:nth-child(6) .njg-valueLabel').textContent;
+    `);
+    const nodesRendered = parseInt(nodes, 10);
+    const linksRendered = parseInt(links, 10);
+    return {nodesRendered, linksRendered};
+  } catch (error) {
+    console.error("Error extracting nodes and links:", error);
+    return {nodesRendered: 0, linksRendered: 0};
+  }
+};
+
+export const getPresentNodesAndLinksCount = async (example) => {
+  const mapping = {
+    "Basic usage": netJsonMap,
+    "Geographic map": netJsonMap,
+    "Multiple interfaces": netJsonMultipleInterfaces,
+    "Search elements": netJsonMap,
+    "Data parse": netJsonMap,
+    "Switch render mode": netJsonMap,
+    "Switch graph mode": netJsonMap,
+    "Nodes expand or fold": netJsonGraphFoldNodes,
+    "Indoor map": netJsonMapIndoorMap,
+    "Leaflet plugins": netJsonMap,
+    "GraphGL render for big data": netJsonGraphGraphGL,
+    "Custom attributes": netJsonElementsLegend,
+    "Multiple links render": netJsonGraphMultipleLinks,
+    "JSONDataUpdate using override option": netJsonNodeTiles1,
+    "JSONDataUpdate using append option": netJsonAppendData1,
+    "Multiple tiles render": netJsonMap,
+    "Geographic map animated links": airplaneRouteMap,
+    "Append data using arrays": {
+      ...netJsonAppendData1,
+      nodes: [
+        ...netJsonAppendData1.nodes,
+        ...netJsonAppendData2.nodes,
+        ...netJsonAppendData3.nodes,
+      ],
+      links: [
+        ...netJsonAppendData1.links,
+        ...netJsonAppendData2.links,
+        ...netJsonAppendData3.links,
+      ],
+    },
+    "Geographic map with GeoJSON data": geoJsonSample,
+    Clustering: netJsonMap,
+  };
+  if (!(example in mapping)) {
+    throw new Error("Invalid example type");
+  }
+  const data = mapping[example];
+  return {nodesPresent: data.nodes.length, linksPresent: data.links.length};
+};
+
+export const captureConsoleErrors = async (driver) => {
+  const logs = await driver.manage().logs().get("browser");
+  return logs.filter(
+    (log) =>
+      log.level.name === "SEVERE" && !log.message.includes("favicon.ico"),
+  );
+};
+
+export const tearDown = async (driver) => {
+  const consoleErrors = await captureConsoleErrors(driver);
+  if (consoleErrors.length > 0) {
+    console.error("Console Errors Detected:");
+    consoleErrors.forEach((error) =>
+      console.error(`${error.level.name}: ${error.message}`),
+    );
+  }
+  await driver.executeScript("window.sessionStorage.clear()");
+  await driver.executeScript("window.localStorage.clear()");
+  await driver.manage().deleteAllCookies();
+  await driver.quit();
+};

--- a/test/browser.test.utils.js
+++ b/test/browser.test.utils.js
@@ -23,6 +23,8 @@ export const getDriver = async () => {
     options.addArguments("--no-sandbox");
     options.addArguments("--disable-dev-shm-usage");
     options.addArguments("--disable-gpu");
+    options.addArguments("--disable-extensions");
+    options.addArguments("--disable-infobars");
     options.addArguments("--remote-debugging-port=9222");
     return new Builder().forBrowser("chrome").setChromeOptions(options).build();
   } catch (err) {

--- a/test/netjsongraph.browser.test.js
+++ b/test/netjsongraph.browser.test.js
@@ -1,0 +1,59 @@
+import {
+  getElementByCss,
+  tearDown,
+  captureConsoleErrors,
+  getDriver,
+  getElementsByCss,
+  getRenderedNodesAndLinksCount,
+  getPresentNodesAndLinksCount,
+  urls,
+} from "./browser.test.utils";
+
+describe("Chart Rendering Test", () => {
+  let driver;
+
+  beforeAll(async () => {
+    driver = await getDriver();
+  });
+
+  afterAll(async () => {
+    await tearDown(driver);
+  });
+
+  test("render the Basic usaage example without console errors", async () => {
+    driver.get(urls.basicUsage);
+    const canvas = await getElementByCss(driver, "canvas", 2000);
+    const consoleErrors = await captureConsoleErrors(driver);
+    const {nodesRendered, linksRendered} =
+      await getRenderedNodesAndLinksCount(driver);
+    const {nodesPresent, linksPresent} =
+      await getPresentNodesAndLinksCount("Geographic map");
+    expect(consoleErrors.length).toBe(0);
+    expect(canvas).not.toBeNull();
+    expect(nodesRendered).toBe(nodesPresent);
+    expect(linksRendered).toBe(linksPresent);
+  });
+
+  test("render the Geographic map example without console errors", async () => {
+    driver.get(urls.geographicMap);
+    const leafletContainer = await getElementByCss(
+      driver,
+      ".ec-extension-leaflet",
+      2000,
+    );
+    const canvases = await getElementsByCss(
+      driver,
+      ".ec-extension-leaflet .leaflet-overlay-pane canvas",
+    );
+    const {nodesRendered, linksRendered} =
+      await getRenderedNodesAndLinksCount(driver);
+    const {nodesPresent, linksPresent} =
+      await getPresentNodesAndLinksCount("Geographic map");
+    const consoleErrors = await captureConsoleErrors(driver);
+    expect(consoleErrors.length).toBe(0);
+    expect(leafletContainer).not.toBeNull();
+    expect(canvases.length).toBeGreaterThan(0);
+    expect(nodesRendered).toBe(nodesPresent);
+    expect(linksRendered).toBe(linksPresent);
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -42,7 +42,7 @@
     "@babel/highlight" "^7.23.4"
     chalk "^2.4.2"
 
-"@babel/code-frame@^7.25.9":
+"@babel/code-frame@^7.25.9", "@babel/code-frame@^7.26.2":
   version "7.26.2"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.26.2.tgz#4b5fab97d33338eff916235055f0ebc21e573a85"
   integrity sha512-RJlIHRueQgwWitWgF8OdFYGZX328Ax5BCemNGlqHfplnRT9ESi8JkFlvaVYbS+UubVY6dpv87Fs2u5M29iNFVQ==
@@ -51,10 +51,10 @@
     js-tokens "^4.0.0"
     picocolors "^1.0.0"
 
-"@babel/compat-data@^7.22.6", "@babel/compat-data@^7.25.9", "@babel/compat-data@^7.26.0":
-  version "7.26.2"
-  resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.26.2.tgz#278b6b13664557de95b8f35b90d96785850bb56e"
-  integrity sha512-Z0WgzSEa+aUcdiJuCIqgujCshpMWgUpgOxXotrYPSA53hA3qopNaqcJpyr0hVb1FeWdnqFA35/fUtXgBK8srQg==
+"@babel/compat-data@^7.22.6", "@babel/compat-data@^7.26.5", "@babel/compat-data@^7.26.8":
+  version "7.26.8"
+  resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.26.8.tgz#821c1d35641c355284d4a870b8a4a7b0c141e367"
+  integrity sha512-oH5UPLMWR3L2wEFLnFJ1TZXqHufiTKAiLfqw5zkhS4dKXLJ10yVztfil/twG8EDTA4F/tvVNw9nOl4ZMslB8rQ==
 
 "@babel/core@^7.11.6", "@babel/core@^7.12.3":
   version "7.20.5"
@@ -127,6 +127,17 @@
     "@jridgewell/trace-mapping" "^0.3.25"
     jsesc "^3.0.2"
 
+"@babel/generator@^7.26.9":
+  version "7.26.9"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.26.9.tgz#75a9482ad3d0cc7188a537aa4910bc59db67cbca"
+  integrity sha512-kEWdzjOAUMW4hAyrzJ0ZaTOu9OmpyDIQicIh0zg0EEcEkYXZb2TjtBhnHi2ViX7PKwZqF4xwqfAm299/QMP3lg==
+  dependencies:
+    "@babel/parser" "^7.26.9"
+    "@babel/types" "^7.26.9"
+    "@jridgewell/gen-mapping" "^0.3.5"
+    "@jridgewell/trace-mapping" "^0.3.25"
+    jsesc "^3.0.2"
+
 "@babel/helper-annotate-as-pure@^7.22.5":
   version "7.22.5"
   resolved "https://registry.yarnpkg.com/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.22.5.tgz#e7f06737b197d580a01edf75d97e2c8be99d3882"
@@ -140,20 +151,12 @@
   dependencies:
     "@babel/types" "^7.25.9"
 
-"@babel/helper-builder-binary-assignment-operator-visitor@^7.25.9":
-  version "7.25.9"
-  resolved "https://registry.yarnpkg.com/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.25.9.tgz#f41752fe772a578e67286e6779a68a5a92de1ee9"
-  integrity sha512-C47lC7LIDCnz0h4vai/tpNOI95tCd5ZT3iBt/DBH5lXKHZsyNQv18yf1wIIg2ntiQNgmAvA+DgZ82iW8Qdym8g==
+"@babel/helper-compilation-targets@^7.20.0", "@babel/helper-compilation-targets@^7.22.6", "@babel/helper-compilation-targets@^7.23.6", "@babel/helper-compilation-targets@^7.25.9", "@babel/helper-compilation-targets@^7.26.5":
+  version "7.26.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-compilation-targets/-/helper-compilation-targets-7.26.5.tgz#75d92bb8d8d51301c0d49e52a65c9a7fe94514d8"
+  integrity sha512-IXuyn5EkouFJscIDuFF5EsiSolseme1s0CZB+QxVugqJLYmKdxI1VfIBOst0SUu4rnk2Z7kqTwmoO1lp3HIfnA==
   dependencies:
-    "@babel/traverse" "^7.25.9"
-    "@babel/types" "^7.25.9"
-
-"@babel/helper-compilation-targets@^7.20.0", "@babel/helper-compilation-targets@^7.22.6", "@babel/helper-compilation-targets@^7.23.6", "@babel/helper-compilation-targets@^7.25.9":
-  version "7.25.9"
-  resolved "https://registry.yarnpkg.com/@babel/helper-compilation-targets/-/helper-compilation-targets-7.25.9.tgz#55af025ce365be3cdc0c1c1e56c6af617ce88875"
-  integrity sha512-j9Db8Suy6yV/VHa4qzrj9yZfZxhLWQdVnRlXxmKLYlhWUVB1sB2G5sxuWYXk/whHD9iW76PmNzxZ4UCnTQTVEQ==
-  dependencies:
-    "@babel/compat-data" "^7.25.9"
+    "@babel/compat-data" "^7.26.5"
     "@babel/helper-validator-option" "^7.25.9"
     browserslist "^4.24.0"
     lru-cache "^5.1.1"
@@ -193,6 +196,17 @@
   version "0.6.2"
   resolved "https://registry.yarnpkg.com/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.6.2.tgz#18594f789c3594acb24cfdb4a7f7b7d2e8bd912d"
   integrity sha512-LV76g+C502biUK6AyZ3LK10vDpDyCzZnhZFXkH1L75zHPj68+qc8Zfpx2th+gzwA2MzyK+1g/3EPl62yFnVttQ==
+  dependencies:
+    "@babel/helper-compilation-targets" "^7.22.6"
+    "@babel/helper-plugin-utils" "^7.22.5"
+    debug "^4.1.1"
+    lodash.debounce "^4.0.8"
+    resolve "^1.14.2"
+
+"@babel/helper-define-polyfill-provider@^0.6.3":
+  version "0.6.3"
+  resolved "https://registry.yarnpkg.com/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.6.3.tgz#f4f2792fae2ef382074bc2d713522cf24e6ddb21"
+  integrity sha512-HK7Bi+Hj6H+VTHA3ZvBis7V/6hu9QuTrnMXNybfUf2iiuU/N97I8VjB+KbhFF8Rld/Lx5MzoCwPCpPjfK+n8Cg==
   dependencies:
     "@babel/helper-compilation-targets" "^7.22.6"
     "@babel/helper-plugin-utils" "^7.22.5"
@@ -250,7 +264,7 @@
     "@babel/helper-split-export-declaration" "^7.22.6"
     "@babel/helper-validator-identifier" "^7.22.20"
 
-"@babel/helper-module-transforms@^7.25.9":
+"@babel/helper-module-transforms@^7.25.9", "@babel/helper-module-transforms@^7.26.0":
   version "7.26.0"
   resolved "https://registry.yarnpkg.com/@babel/helper-module-transforms/-/helper-module-transforms-7.26.0.tgz#8ce54ec9d592695e58d84cd884b7b5c6a2fdeeae"
   integrity sha512-xO+xu6B5K2czEnQye6BHA7DolFFmS3LB7stHZFaOLb1pAwO1HWLS8fXA+eh0A2yIvltPVmx3eNNDBJA2SLHXFw==
@@ -266,10 +280,10 @@
   dependencies:
     "@babel/types" "^7.25.9"
 
-"@babel/helper-plugin-utils@^7.0.0", "@babel/helper-plugin-utils@^7.10.4", "@babel/helper-plugin-utils@^7.12.13", "@babel/helper-plugin-utils@^7.14.5", "@babel/helper-plugin-utils@^7.18.6", "@babel/helper-plugin-utils@^7.19.0", "@babel/helper-plugin-utils@^7.22.5", "@babel/helper-plugin-utils@^7.25.9", "@babel/helper-plugin-utils@^7.8.0":
-  version "7.25.9"
-  resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.25.9.tgz#9cbdd63a9443a2c92a725cca7ebca12cc8dd9f46"
-  integrity sha512-kSMlyUVdWe25rEsRGviIgOWnoT/nfABVWlqt9N19/dIPWViAOW2s9wznP5tURbs/IDuNk4gPy3YdYRgH3uxhBw==
+"@babel/helper-plugin-utils@^7.0.0", "@babel/helper-plugin-utils@^7.10.4", "@babel/helper-plugin-utils@^7.12.13", "@babel/helper-plugin-utils@^7.14.5", "@babel/helper-plugin-utils@^7.18.6", "@babel/helper-plugin-utils@^7.19.0", "@babel/helper-plugin-utils@^7.22.5", "@babel/helper-plugin-utils@^7.25.9", "@babel/helper-plugin-utils@^7.26.5", "@babel/helper-plugin-utils@^7.8.0":
+  version "7.26.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.26.5.tgz#18580d00c9934117ad719392c4f6585c9333cc35"
+  integrity sha512-RS+jZcRdZdRFzMyr+wcsaqOmld1/EqTghfaBGQQd/WnRdzdlvSZ//kF7U8VQTxf1ynZ4cjUcYgjVGx13ewNPMg==
 
 "@babel/helper-remap-async-to-generator@^7.25.9":
   version "7.25.9"
@@ -294,14 +308,6 @@
   resolved "https://registry.yarnpkg.com/@babel/helper-simple-access/-/helper-simple-access-7.22.5.tgz#4938357dc7d782b80ed6dbb03a0fba3d22b1d5de"
   dependencies:
     "@babel/types" "^7.22.5"
-
-"@babel/helper-simple-access@^7.25.9":
-  version "7.25.9"
-  resolved "https://registry.yarnpkg.com/@babel/helper-simple-access/-/helper-simple-access-7.25.9.tgz#6d51783299884a2c74618d6ef0f86820ec2e7739"
-  integrity sha512-c6WHXuiaRsJTyHYLJV75t9IqsmTbItYfdj99PnzYGQZkYKvan5/2jKJ7gu31J3/BJ/A18grImSPModuyG/Eo0Q==
-  dependencies:
-    "@babel/traverse" "^7.25.9"
-    "@babel/types" "^7.25.9"
 
 "@babel/helper-skip-transparent-expression-wrappers@^7.25.9":
   version "7.25.9"
@@ -403,6 +409,13 @@
   integrity sha512-DWMCZH9WA4Maitz2q21SRKHo9QXZxkDsbNZoVD62gusNtNBBqDg9i7uOhASfTfIGNzW+O+r7+jAlM8dwphcJKQ==
   dependencies:
     "@babel/types" "^7.26.0"
+
+"@babel/parser@^7.26.9":
+  version "7.26.9"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.26.9.tgz#d9e78bee6dc80f9efd8f2349dcfbbcdace280fd5"
+  integrity sha512-81NWa1njQblgZbQHxWHpxxCzNsa3ZwvFqpUg7P+NNUU6f3UU2jBEg4OlF/J6rl8+PQGh1q6/zWScd001YwcA5A==
+  dependencies:
+    "@babel/types" "^7.26.9"
 
 "@babel/plugin-bugfix-firefox-class-in-computed-class-key@^7.25.9":
   version "7.25.9"
@@ -560,14 +573,14 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.25.9"
 
-"@babel/plugin-transform-async-generator-functions@^7.25.9":
-  version "7.25.9"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-async-generator-functions/-/plugin-transform-async-generator-functions-7.25.9.tgz#1b18530b077d18a407c494eb3d1d72da505283a2"
-  integrity sha512-RXV6QAzTBbhDMO9fWwOmwwTuYaiPbggWQ9INdZqAYeSHyG7FzQ+nOZaUUjNwKv9pV3aE4WFqFm1Hnbci5tBCAw==
+"@babel/plugin-transform-async-generator-functions@^7.26.8":
+  version "7.26.8"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-async-generator-functions/-/plugin-transform-async-generator-functions-7.26.8.tgz#5e3991135e3b9c6eaaf5eff56d1ae5a11df45ff8"
+  integrity sha512-He9Ej2X7tNf2zdKMAGOsmg2MrFc+hfoAhd3po4cWfo/NWjzEAKa0oQruj1ROVUdl0e6fb6/kE/G3SSxE0lRJOg==
   dependencies:
-    "@babel/helper-plugin-utils" "^7.25.9"
+    "@babel/helper-plugin-utils" "^7.26.5"
     "@babel/helper-remap-async-to-generator" "^7.25.9"
-    "@babel/traverse" "^7.25.9"
+    "@babel/traverse" "^7.26.8"
 
 "@babel/plugin-transform-async-to-generator@^7.25.9":
   version "7.25.9"
@@ -578,12 +591,12 @@
     "@babel/helper-plugin-utils" "^7.25.9"
     "@babel/helper-remap-async-to-generator" "^7.25.9"
 
-"@babel/plugin-transform-block-scoped-functions@^7.25.9":
-  version "7.25.9"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.25.9.tgz#5700691dbd7abb93de300ca7be94203764fce458"
-  integrity sha512-toHc9fzab0ZfenFpsyYinOX0J/5dgJVA2fm64xPewu7CoYHWEivIWKxkK2rMi4r3yQqLnVmheMXRdG+k239CgA==
+"@babel/plugin-transform-block-scoped-functions@^7.26.5":
+  version "7.26.5"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.26.5.tgz#3dc4405d31ad1cbe45293aa57205a6e3b009d53e"
+  integrity sha512-chuTSY+hq09+/f5lMj8ZSYgCFpppV2CbYrhNFJ1BFoXpiWPnnAb7R0MqrafCpN8E1+YRrtM1MXZHJdIx8B6rMQ==
   dependencies:
-    "@babel/helper-plugin-utils" "^7.25.9"
+    "@babel/helper-plugin-utils" "^7.26.5"
 
 "@babel/plugin-transform-block-scoping@^7.25.9":
   version "7.25.9"
@@ -665,12 +678,11 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.25.9"
 
-"@babel/plugin-transform-exponentiation-operator@^7.25.9":
-  version "7.25.9"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.25.9.tgz#ece47b70d236c1d99c263a1e22b62dc20a4c8b0f"
-  integrity sha512-KRhdhlVk2nObA5AYa7QMgTMTVJdfHprfpAk4DjZVtllqRg9qarilstTKEhpVjyt+Npi8ThRyiV8176Am3CodPA==
+"@babel/plugin-transform-exponentiation-operator@^7.26.3":
+  version "7.26.3"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.26.3.tgz#e29f01b6de302c7c2c794277a48f04a9ca7f03bc"
+  integrity sha512-7CAHcQ58z2chuXPWblnn1K6rLDnDWieghSOEmqQsrBenH0P9InCUtOJYD89pvngljmZlJcz3fcmgYsXFNGa1ZQ==
   dependencies:
-    "@babel/helper-builder-binary-assignment-operator-visitor" "^7.25.9"
     "@babel/helper-plugin-utils" "^7.25.9"
 
 "@babel/plugin-transform-export-namespace-from@^7.25.9":
@@ -680,12 +692,12 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.25.9"
 
-"@babel/plugin-transform-for-of@^7.25.9":
-  version "7.25.9"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.25.9.tgz#4bdc7d42a213397905d89f02350c5267866d5755"
-  integrity sha512-LqHxduHoaGELJl2uhImHwRQudhCM50pT46rIBNvtT/Oql3nqiS3wOwP+5ten7NpYSXrrVLgtZU3DZmPtWZo16A==
+"@babel/plugin-transform-for-of@^7.26.9":
+  version "7.26.9"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.26.9.tgz#27231f79d5170ef33b5111f07fe5cafeb2c96a56"
+  integrity sha512-Hry8AusVm8LW5BVFgiyUReuoGzPUpdHQQqJY5bZnbbf+ngOHWuCuYFKw/BqaaWlvEUrF91HMhDtEaI1hZzNbLg==
   dependencies:
-    "@babel/helper-plugin-utils" "^7.25.9"
+    "@babel/helper-plugin-utils" "^7.26.5"
     "@babel/helper-skip-transparent-expression-wrappers" "^7.25.9"
 
 "@babel/plugin-transform-function-name@^7.25.9":
@@ -733,14 +745,13 @@
     "@babel/helper-module-transforms" "^7.25.9"
     "@babel/helper-plugin-utils" "^7.25.9"
 
-"@babel/plugin-transform-modules-commonjs@^7.25.9":
-  version "7.25.9"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.25.9.tgz#d165c8c569a080baf5467bda88df6425fc060686"
-  integrity sha512-dwh2Ol1jWwL2MgkCzUSOvfmKElqQcuswAZypBSUsScMXvgdT8Ekq5YA6TtqpTVWH+4903NmboMuH1o9i8Rxlyg==
+"@babel/plugin-transform-modules-commonjs@^7.26.3":
+  version "7.26.3"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.26.3.tgz#8f011d44b20d02c3de44d8850d971d8497f981fb"
+  integrity sha512-MgR55l4q9KddUDITEzEFYn5ZsGDXMSsU9E+kh7fjRXTIC3RHqfCo8RPRbyReYJh44HQ/yomFkqbOFohXvDCiIQ==
   dependencies:
-    "@babel/helper-module-transforms" "^7.25.9"
+    "@babel/helper-module-transforms" "^7.26.0"
     "@babel/helper-plugin-utils" "^7.25.9"
-    "@babel/helper-simple-access" "^7.25.9"
 
 "@babel/plugin-transform-modules-systemjs@^7.25.9":
   version "7.25.9"
@@ -775,12 +786,12 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.25.9"
 
-"@babel/plugin-transform-nullish-coalescing-operator@^7.25.9":
-  version "7.25.9"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-nullish-coalescing-operator/-/plugin-transform-nullish-coalescing-operator-7.25.9.tgz#bcb1b0d9e948168102d5f7104375ca21c3266949"
-  integrity sha512-ENfftpLZw5EItALAD4WsY/KUWvhUlZndm5GC7G3evUsVeSJB6p0pBeLQUnRnBCBx7zV0RKQjR9kCuwrsIrjWog==
+"@babel/plugin-transform-nullish-coalescing-operator@^7.26.6":
+  version "7.26.6"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-nullish-coalescing-operator/-/plugin-transform-nullish-coalescing-operator-7.26.6.tgz#fbf6b3c92cb509e7b319ee46e3da89c5bedd31fe"
+  integrity sha512-CKW8Vu+uUZneQCPtXmSBUC6NCAUdya26hWCElAWh5mVSlSRsmiCPUUDKb3Z0szng1hiAJa098Hkhg9o4SE35Qw==
   dependencies:
-    "@babel/helper-plugin-utils" "^7.25.9"
+    "@babel/helper-plugin-utils" "^7.26.5"
 
 "@babel/plugin-transform-numeric-separator@^7.25.9":
   version "7.25.9"
@@ -897,19 +908,19 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.25.9"
 
-"@babel/plugin-transform-template-literals@^7.25.9":
-  version "7.25.9"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.25.9.tgz#6dbd4a24e8fad024df76d1fac6a03cf413f60fe1"
-  integrity sha512-o97AE4syN71M/lxrCtQByzphAdlYluKPDBzDVzMmfCobUjjhAryZV0AIpRPrxN0eAkxXO6ZLEScmt+PNhj2OTw==
+"@babel/plugin-transform-template-literals@^7.26.8":
+  version "7.26.8"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.26.8.tgz#966b15d153a991172a540a69ad5e1845ced990b5"
+  integrity sha512-OmGDL5/J0CJPJZTHZbi2XpO0tyT2Ia7fzpW5GURwdtp2X3fMmN8au/ej6peC/T33/+CRiIpA8Krse8hFGVmT5Q==
   dependencies:
-    "@babel/helper-plugin-utils" "^7.25.9"
+    "@babel/helper-plugin-utils" "^7.26.5"
 
-"@babel/plugin-transform-typeof-symbol@^7.25.9":
-  version "7.25.9"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.25.9.tgz#224ba48a92869ddbf81f9b4a5f1204bbf5a2bc4b"
-  integrity sha512-v61XqUMiueJROUv66BVIOi0Fv/CUuZuZMl5NkRoCVxLAnMexZ0A3kMe7vvZ0nulxMuMp0Mk6S5hNh48yki08ZA==
+"@babel/plugin-transform-typeof-symbol@^7.26.7":
+  version "7.26.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.26.7.tgz#d0e33acd9223744c1e857dbd6fa17bd0a3786937"
+  integrity sha512-jfoTXXZTgGg36BmhqT3cAYK5qkmqvJpvNrPhaK/52Vgjhw4Rq29s9UqpWWV0D6yuRmgiFH/BUVlkl96zJWqnaw==
   dependencies:
-    "@babel/helper-plugin-utils" "^7.25.9"
+    "@babel/helper-plugin-utils" "^7.26.5"
 
 "@babel/plugin-transform-unicode-escapes@^7.25.9":
   version "7.25.9"
@@ -943,13 +954,13 @@
     "@babel/helper-plugin-utils" "^7.25.9"
 
 "@babel/preset-env@^7.23.9":
-  version "7.26.0"
-  resolved "https://registry.yarnpkg.com/@babel/preset-env/-/preset-env-7.26.0.tgz#30e5c6bc1bcc54865bff0c5a30f6d4ccdc7fa8b1"
-  integrity sha512-H84Fxq0CQJNdPFT2DrfnylZ3cf5K43rGfWK4LJGPpjKHiZlk0/RzwEus3PDDZZg+/Er7lCA03MVacueUuXdzfw==
+  version "7.26.9"
+  resolved "https://registry.yarnpkg.com/@babel/preset-env/-/preset-env-7.26.9.tgz#2ec64e903d0efe743699f77a10bdf7955c2123c3"
+  integrity sha512-vX3qPGE8sEKEAZCWk05k3cpTAE3/nOYca++JA+Rd0z2NCNzabmYvEiSShKzm10zdquOIAVXsy2Ei/DTW34KlKQ==
   dependencies:
-    "@babel/compat-data" "^7.26.0"
-    "@babel/helper-compilation-targets" "^7.25.9"
-    "@babel/helper-plugin-utils" "^7.25.9"
+    "@babel/compat-data" "^7.26.8"
+    "@babel/helper-compilation-targets" "^7.26.5"
+    "@babel/helper-plugin-utils" "^7.26.5"
     "@babel/helper-validator-option" "^7.25.9"
     "@babel/plugin-bugfix-firefox-class-in-computed-class-key" "^7.25.9"
     "@babel/plugin-bugfix-safari-class-field-initializer-scope" "^7.25.9"
@@ -961,9 +972,9 @@
     "@babel/plugin-syntax-import-attributes" "^7.26.0"
     "@babel/plugin-syntax-unicode-sets-regex" "^7.18.6"
     "@babel/plugin-transform-arrow-functions" "^7.25.9"
-    "@babel/plugin-transform-async-generator-functions" "^7.25.9"
+    "@babel/plugin-transform-async-generator-functions" "^7.26.8"
     "@babel/plugin-transform-async-to-generator" "^7.25.9"
-    "@babel/plugin-transform-block-scoped-functions" "^7.25.9"
+    "@babel/plugin-transform-block-scoped-functions" "^7.26.5"
     "@babel/plugin-transform-block-scoping" "^7.25.9"
     "@babel/plugin-transform-class-properties" "^7.25.9"
     "@babel/plugin-transform-class-static-block" "^7.26.0"
@@ -974,21 +985,21 @@
     "@babel/plugin-transform-duplicate-keys" "^7.25.9"
     "@babel/plugin-transform-duplicate-named-capturing-groups-regex" "^7.25.9"
     "@babel/plugin-transform-dynamic-import" "^7.25.9"
-    "@babel/plugin-transform-exponentiation-operator" "^7.25.9"
+    "@babel/plugin-transform-exponentiation-operator" "^7.26.3"
     "@babel/plugin-transform-export-namespace-from" "^7.25.9"
-    "@babel/plugin-transform-for-of" "^7.25.9"
+    "@babel/plugin-transform-for-of" "^7.26.9"
     "@babel/plugin-transform-function-name" "^7.25.9"
     "@babel/plugin-transform-json-strings" "^7.25.9"
     "@babel/plugin-transform-literals" "^7.25.9"
     "@babel/plugin-transform-logical-assignment-operators" "^7.25.9"
     "@babel/plugin-transform-member-expression-literals" "^7.25.9"
     "@babel/plugin-transform-modules-amd" "^7.25.9"
-    "@babel/plugin-transform-modules-commonjs" "^7.25.9"
+    "@babel/plugin-transform-modules-commonjs" "^7.26.3"
     "@babel/plugin-transform-modules-systemjs" "^7.25.9"
     "@babel/plugin-transform-modules-umd" "^7.25.9"
     "@babel/plugin-transform-named-capturing-groups-regex" "^7.25.9"
     "@babel/plugin-transform-new-target" "^7.25.9"
-    "@babel/plugin-transform-nullish-coalescing-operator" "^7.25.9"
+    "@babel/plugin-transform-nullish-coalescing-operator" "^7.26.6"
     "@babel/plugin-transform-numeric-separator" "^7.25.9"
     "@babel/plugin-transform-object-rest-spread" "^7.25.9"
     "@babel/plugin-transform-object-super" "^7.25.9"
@@ -1004,17 +1015,17 @@
     "@babel/plugin-transform-shorthand-properties" "^7.25.9"
     "@babel/plugin-transform-spread" "^7.25.9"
     "@babel/plugin-transform-sticky-regex" "^7.25.9"
-    "@babel/plugin-transform-template-literals" "^7.25.9"
-    "@babel/plugin-transform-typeof-symbol" "^7.25.9"
+    "@babel/plugin-transform-template-literals" "^7.26.8"
+    "@babel/plugin-transform-typeof-symbol" "^7.26.7"
     "@babel/plugin-transform-unicode-escapes" "^7.25.9"
     "@babel/plugin-transform-unicode-property-regex" "^7.25.9"
     "@babel/plugin-transform-unicode-regex" "^7.25.9"
     "@babel/plugin-transform-unicode-sets-regex" "^7.25.9"
     "@babel/preset-modules" "0.1.6-no-external-plugins"
     babel-plugin-polyfill-corejs2 "^0.4.10"
-    babel-plugin-polyfill-corejs3 "^0.10.6"
+    babel-plugin-polyfill-corejs3 "^0.11.0"
     babel-plugin-polyfill-regenerator "^0.6.1"
-    core-js-compat "^3.38.1"
+    core-js-compat "^3.40.0"
     semver "^6.3.1"
 
 "@babel/preset-modules@0.1.6-no-external-plugins":
@@ -1062,6 +1073,15 @@
     "@babel/parser" "^7.25.9"
     "@babel/types" "^7.25.9"
 
+"@babel/template@^7.26.9":
+  version "7.26.9"
+  resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.26.9.tgz#4577ad3ddf43d194528cff4e1fa6b232fa609bb2"
+  integrity sha512-qyRplbeIpNZhmzOysF/wFMuP9sctmh2cFzRAZOn1YapxBsE1i9bJIY586R/WBLfLcmcBlM8ROBiQURnnNy+zfA==
+  dependencies:
+    "@babel/code-frame" "^7.26.2"
+    "@babel/parser" "^7.26.9"
+    "@babel/types" "^7.26.9"
+
 "@babel/traverse@^7.20.5":
   version "7.23.2"
   resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.23.2.tgz#329c7a06735e144a506bdb2cad0268b7f46f4ad8"
@@ -1106,6 +1126,19 @@
     debug "^4.3.1"
     globals "^11.1.0"
 
+"@babel/traverse@^7.26.8":
+  version "7.26.9"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.26.9.tgz#4398f2394ba66d05d988b2ad13c219a2c857461a"
+  integrity sha512-ZYW7L+pL8ahU5fXmNbPF+iZFHCv5scFak7MZ9bwaRPLUhHh7QQEMjZUg0HevihoqCM5iSYHN61EyCoZvqC+bxg==
+  dependencies:
+    "@babel/code-frame" "^7.26.2"
+    "@babel/generator" "^7.26.9"
+    "@babel/parser" "^7.26.9"
+    "@babel/template" "^7.26.9"
+    "@babel/types" "^7.26.9"
+    debug "^4.3.1"
+    globals "^11.1.0"
+
 "@babel/types@^7.0.0", "@babel/types@^7.20.5", "@babel/types@^7.22.15", "@babel/types@^7.22.5", "@babel/types@^7.23.0", "@babel/types@^7.3.0", "@babel/types@^7.3.3", "@babel/types@^7.4.4":
   version "7.23.0"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.23.0.tgz#8c1f020c9df0e737e4e247c0619f58c68458aaeb"
@@ -1127,6 +1160,14 @@
   version "7.26.0"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.26.0.tgz#deabd08d6b753bc8e0f198f8709fb575e31774ff"
   integrity sha512-Z/yiTPj+lDVnF7lWeKCIJzaIkI0vYO87dMpZ4bg4TDrFe4XXLFWL1TbXU27gBP3QccxV9mZICCrnjnYlJjXHOA==
+  dependencies:
+    "@babel/helper-string-parser" "^7.25.9"
+    "@babel/helper-validator-identifier" "^7.25.9"
+
+"@babel/types@^7.26.9":
+  version "7.26.9"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.26.9.tgz#08b43dec79ee8e682c2ac631c010bdcac54a21ce"
+  integrity sha512-Y3IR1cRnOxOCDvMmNiym7XpXQ93iGDDPHx+Zj+NM+rg0fBaShfQLkg+hKPaZCEvg5N/LeCo4+Rj/i3FuJsIQaw==
   dependencies:
     "@babel/helper-string-parser" "^7.25.9"
     "@babel/helper-validator-identifier" "^7.25.9"
@@ -2271,13 +2312,13 @@ babel-plugin-polyfill-corejs2@^0.4.10:
     "@babel/helper-define-polyfill-provider" "^0.6.2"
     semver "^6.3.1"
 
-babel-plugin-polyfill-corejs3@^0.10.6:
-  version "0.10.6"
-  resolved "https://registry.yarnpkg.com/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.10.6.tgz#2deda57caef50f59c525aeb4964d3b2f867710c7"
-  integrity sha512-b37+KR2i/khY5sKmWNVQAnitvquQbNdWy6lJdsr0kmquCKEEUgMKK4SboVM3HtfnZilfjr4MMQ7vY58FVWDtIA==
+babel-plugin-polyfill-corejs3@^0.11.0:
+  version "0.11.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.11.1.tgz#4e4e182f1bb37c7ba62e2af81d8dd09df31344f6"
+  integrity sha512-yGCqvBT4rwMczo28xkH/noxJ6MZ4nJfkVYdoDaC/utLtWrXxv27HVrzAeSbqR8SxDsp46n0YF47EbHoixy6rXQ==
   dependencies:
-    "@babel/helper-define-polyfill-provider" "^0.6.2"
-    core-js-compat "^3.38.0"
+    "@babel/helper-define-polyfill-provider" "^0.6.3"
+    core-js-compat "^3.40.0"
 
 babel-plugin-polyfill-regenerator@^0.6.1:
   version "0.6.2"
@@ -2373,7 +2414,7 @@ braces@^3.0.3, braces@~3.0.2:
   dependencies:
     fill-range "^7.1.1"
 
-browserslist@^4.24.0, browserslist@^4.24.2:
+browserslist@^4.24.0:
   version "4.24.2"
   resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.24.2.tgz#f5845bc91069dbd55ee89faf9822e1d885d16580"
   integrity sha512-ZIc+Q62revdMcqC6aChtW4jz3My3klmCO1fEmINZY/8J3EpBg5/A/D0AKmBveUh6pgoeycoMkVMko84tuYS+Gg==
@@ -2381,6 +2422,16 @@ browserslist@^4.24.0, browserslist@^4.24.2:
     caniuse-lite "^1.0.30001669"
     electron-to-chromium "^1.5.41"
     node-releases "^2.0.18"
+    update-browserslist-db "^1.1.1"
+
+browserslist@^4.24.3:
+  version "4.24.4"
+  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.24.4.tgz#c6b2865a3f08bcb860a0e827389003b9fe686e4b"
+  integrity sha512-KDi1Ny1gSePi1vm0q4oxSF8b4DR44GF4BbmS2YdhPLOEqd8pDviZOGH/GsmRwoWJ2+5Lr085X7naowMwKHDG1A==
+  dependencies:
+    caniuse-lite "^1.0.30001688"
+    electron-to-chromium "^1.5.73"
+    node-releases "^2.0.19"
     update-browserslist-db "^1.1.1"
 
 bser@^2.0.0:
@@ -2472,6 +2523,11 @@ caniuse-lite@^1.0.30001669:
   version "1.0.30001676"
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001676.tgz#fe133d41fe74af8f7cc93b8a714c3e86a86e6f04"
   integrity sha512-Qz6zwGCiPghQXGJvgQAem79esjitvJ+CxSbSQkW9H/UX5hg8XM88d4lp2W+MEQ81j+Hip58Il+jGVdazk1z9cw==
+
+caniuse-lite@^1.0.30001688:
+  version "1.0.30001701"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001701.tgz#ad9c90301f7153cf6b3314d16cc30757285bf9e7"
+  integrity sha512-faRs/AW3jA9nTwmJBSO1PQ6L/EOgsB5HMQQq4iCu5zhPgVVgO/pZRHlmatwijZKetFw8/Pr4q6dEN8sJuq8qTw==
 
 caseless@~0.12.0:
   version "0.12.0"
@@ -2710,12 +2766,12 @@ copy-webpack-plugin@^12.0.2:
     schema-utils "^4.2.0"
     serialize-javascript "^6.0.2"
 
-core-js-compat@^3.38.0, core-js-compat@^3.38.1:
-  version "3.39.0"
-  resolved "https://registry.yarnpkg.com/core-js-compat/-/core-js-compat-3.39.0.tgz#b12dccb495f2601dc860bdbe7b4e3ffa8ba63f61"
-  integrity sha512-VgEUx3VwlExr5no0tXlBt+silBvhTryPwCXRI2Id1PN8WTKu7MreethvddqOubrYxkFdv/RnYrqlv1sFNAUelw==
+core-js-compat@^3.40.0:
+  version "3.40.0"
+  resolved "https://registry.yarnpkg.com/core-js-compat/-/core-js-compat-3.40.0.tgz#7485912a5a4a4315c2fdb2cbdc623e6881c88b38"
+  integrity sha512-0XEDpr5y5mijvw8Lbc6E5AkjrHfp7eEoPlu36SWeAbcL8fn1G1ANe8DBlo2XoNN89oVpxWwOjYIPVzR4ZvsKCQ==
   dependencies:
-    browserslist "^4.24.2"
+    browserslist "^4.24.3"
 
 core-util-is@~1.0.0:
   version "1.0.2"
@@ -3103,6 +3159,11 @@ electron-to-chromium@^1.5.41:
   version "1.5.50"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.5.50.tgz#d9ba818da7b2b5ef1f3dd32bce7046feb7e93234"
   integrity sha512-eMVObiUQ2LdgeO1F/ySTXsvqvxb6ZH2zPGaMYsWzRDdOddUa77tdmI0ltg+L16UpbWdhPmuF3wIQYyQq65WfZw==
+
+electron-to-chromium@^1.5.73:
+  version "1.5.105"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.5.105.tgz#0b2396e7e1a467434cd3132950bbe53c04f74a5e"
+  integrity sha512-ccp7LocdXx3yBhwiG0qTQ7XFrK48Ua2pxIxBdJO8cbddp/MvbBtPFzvnTchtyHQTsgqqczO8cdmAIbpMa0u2+g==
 
 emittery@^0.13.1:
   version "0.13.1"
@@ -5675,6 +5736,11 @@ node-releases@^2.0.18:
   version "2.0.18"
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-2.0.18.tgz#f010e8d35e2fe8d6b2944f03f70213ecedc4ca3f"
   integrity sha512-d9VeXT4SJ7ZeOqGX6R5EM022wpL+eWPooLI+5UpWn2jCT1aosUQEhQP214x33Wkwx3JQMvIm+tIoVOdodFS40g==
+
+node-releases@^2.0.19:
+  version "2.0.19"
+  resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-2.0.19.tgz#9e445a52950951ec4d177d843af370b411caf314"
+  integrity sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==
 
 normalize-path@^3.0.0, normalize-path@~3.0.0:
   version "3.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1509,11 +1509,11 @@
     "@nodelib/fs.stat" "2.0.5"
     run-parallel "^1.1.9"
 
-"@nodelib/fs.stat@2.0.5", "@nodelib/fs.stat@^2.0.2":
+"@nodelib/fs.stat@2.0.5":
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz#5bd262af94e9d25bd1e71b05deed44876a222e8b"
 
-"@nodelib/fs.walk@^1.2.3", "@nodelib/fs.walk@^1.2.8":
+"@nodelib/fs.walk@^1.2.8":
   version "1.2.8"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz#e95737e8bb6746ddedf69c556953494f196fe69a"
   dependencies:
@@ -1529,11 +1529,6 @@
   version "0.27.8"
   resolved "https://registry.yarnpkg.com/@sinclair/typebox/-/typebox-0.27.8.tgz#6667fac16c436b5434a387a34dedb013198f6e6e"
   integrity sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==
-
-"@sindresorhus/merge-streams@^2.1.0":
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/@sindresorhus/merge-streams/-/merge-streams-2.3.0.tgz#719df7fb41766bc143369eaa0dd56d8dc87c9958"
-  integrity sha512-LtoMMhxAlorcGhmFYI+LhPgbPZCkgP6ra1YL604EeF6U98pLlQ3iWIGMdWSC+vWmPBWBNgmDBAhnAobLROJmwg==
 
 "@sinonjs/commons@^3.0.0":
   version "3.0.0"
@@ -2750,17 +2745,16 @@ cookie@0.7.1:
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.7.1.tgz#2f73c42142d5d5cf71310a74fc4ae61670e5dbc9"
   integrity sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==
 
-copy-webpack-plugin@^12.0.2:
-  version "12.0.2"
-  resolved "https://registry.yarnpkg.com/copy-webpack-plugin/-/copy-webpack-plugin-12.0.2.tgz#935e57b8e6183c82f95bd937df658a59f6a2da28"
-  integrity sha512-SNwdBeHyII+rWvee/bTnAYyO8vfVdcSTud4EIb6jcZ8inLeWucJE0DnxXQBjlQ5zlteuuvooGQy3LIyGxhvlOA==
+copy-webpack-plugin@^13.0.0:
+  version "13.0.0"
+  resolved "https://registry.yarnpkg.com/copy-webpack-plugin/-/copy-webpack-plugin-13.0.0.tgz#793342576eed76fdbc7936b873eae17aa7a7d9a3"
+  integrity sha512-FgR/h5a6hzJqATDGd9YG41SeDViH+0bkHn6WNXCi5zKAZkeESeSxLySSsFLHqLEVCh0E+rITmCf0dusXWYukeQ==
   dependencies:
-    fast-glob "^3.3.2"
     glob-parent "^6.0.1"
-    globby "^14.0.0"
     normalize-path "^3.0.0"
     schema-utils "^4.2.0"
     serialize-javascript "^6.0.2"
+    tinyglobby "^0.2.12"
 
 core-js-compat@^3.40.0:
   version "3.40.0"
@@ -3814,17 +3808,6 @@ fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
 
-fast-glob@^3.3.2:
-  version "3.3.2"
-  resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.3.2.tgz#a904501e57cfdd2ffcded45e99a54fef55e46129"
-  integrity sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==
-  dependencies:
-    "@nodelib/fs.stat" "^2.0.2"
-    "@nodelib/fs.walk" "^1.2.3"
-    glob-parent "^5.1.2"
-    merge2 "^1.3.0"
-    micromatch "^4.0.4"
-
 fast-json-stable-stringify@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz#d5142c0caee6b1189f87d3a76111064f86c8bbf2"
@@ -3859,6 +3842,11 @@ fb-watchman@^2.0.0:
   resolved "https://registry.yarnpkg.com/fb-watchman/-/fb-watchman-2.0.0.tgz#54e9abf7dfa2f26cd9b1636c588c1afc05de5d58"
   dependencies:
     bser "^2.0.0"
+
+fdir@^6.4.3:
+  version "6.4.3"
+  resolved "https://registry.yarnpkg.com/fdir/-/fdir-6.4.3.tgz#011cdacf837eca9b811c89dbb902df714273db72"
+  integrity sha512-PMXmW2y1hDDfTSRc9gaXIuCCRpuoz3Kaz8cUelp3smouvfT632ozg2vrT6lJsHKKOF59YLbOGfAWGUcKEfRMQw==
 
 file-entry-cache@^6.0.1:
   version "6.0.1"
@@ -4071,17 +4059,17 @@ getpass@^0.1.1:
   dependencies:
     assert-plus "^1.0.0"
 
-glob-parent@^5.1.2, glob-parent@~5.1.2:
-  version "5.1.2"
-  resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-5.1.2.tgz#869832c58034fe68a4093c17dc15e8340d8401c4"
-  dependencies:
-    is-glob "^4.0.1"
-
 glob-parent@^6.0.1, glob-parent@^6.0.2:
   version "6.0.2"
   resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-6.0.2.tgz#6d237d99083950c79290f24c7642a3de9a28f9e3"
   dependencies:
     is-glob "^4.0.3"
+
+glob-parent@~5.1.2:
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-5.1.2.tgz#869832c58034fe68a4093c17dc15e8340d8401c4"
+  dependencies:
+    is-glob "^4.0.1"
 
 glob-to-regexp@^0.4.1:
   version "0.4.1"
@@ -4123,18 +4111,6 @@ globalthis@^1.0.4:
   dependencies:
     define-properties "^1.2.1"
     gopd "^1.0.1"
-
-globby@^14.0.0:
-  version "14.0.1"
-  resolved "https://registry.yarnpkg.com/globby/-/globby-14.0.1.tgz#a1b44841aa7f4c6d8af2bc39951109d77301959b"
-  integrity sha512-jOMLD2Z7MAhyG8aJpNOpmziMOP4rPLcc95oQPKXBazW82z+CEgPFBQvEpRUa1KeIMUJo4Wsm+q6uzO/Q/4BksQ==
-  dependencies:
-    "@sindresorhus/merge-streams" "^2.1.0"
-    fast-glob "^3.3.2"
-    ignore "^5.2.4"
-    path-type "^5.0.0"
-    slash "^5.1.0"
-    unicorn-magic "^0.1.0"
 
 gopd@^1.0.1:
   version "1.0.1"
@@ -4398,7 +4374,7 @@ identity-obj-proxy@^3.0.0:
   dependencies:
     harmony-reflect "^1.4.6"
 
-ignore@^5.2.0, ignore@^5.2.4:
+ignore@^5.2.0:
   version "5.3.1"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.3.1.tgz#5073e554cd42c5b33b394375f538b8593e34d4ef"
   integrity sha512-5Fytz/IraMjqpwfd34ke28PTVMjZjJG2MPn5t7OE4eUCUNf8BAa7b5WUS9/Qvr6mwOQS7Mk6vdsMno5he+T8Xw==
@@ -5620,10 +5596,6 @@ merge-stream@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/merge-stream/-/merge-stream-2.0.0.tgz#52823629a14dd00c9770fb6ad47dc6310f2c1f60"
 
-merge2@^1.3.0:
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.4.1.tgz#4368892f885e907455a6fd7dc55c0c9d404990ae"
-
 methods@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/methods/-/methods-1.1.2.tgz#5529a4d67654134edcc5266656835b0f851afcee"
@@ -6035,11 +6007,6 @@ path-to-regexp@0.1.12:
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-0.1.12.tgz#d5e1a12e478a976d432ef3c58d534b9923164bb7"
   integrity sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==
 
-path-type@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/path-type/-/path-type-5.0.0.tgz#14b01ed7aea7ddf9c7c3f46181d4d04f9c785bb8"
-  integrity sha512-5HviZNaZcfqP95rwpv+1HDgUamezbqdSYTyzjTvwtJSnIH+3vnbmWsItli8OFEndS984VT55M3jduxZbX351gg==
-
 performance-now@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
@@ -6056,6 +6023,11 @@ picocolors@^1.1.0:
 picomatch@^2.0.4, picomatch@^2.2.1, picomatch@^2.2.3, picomatch@^2.3.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.1.tgz#3ba3833733646d9d3e4995946c1365a67fb07a42"
+
+picomatch@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-4.0.2.tgz#77c742931e8f3b8820946c76cd0c1f13730d1dab"
+  integrity sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==
 
 pidtree@^0.6.0:
   version "0.6.0"
@@ -6844,11 +6816,6 @@ slash@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/slash/-/slash-3.0.0.tgz#6539be870c165adbd5240220dbe361f1bc4d4634"
 
-slash@^5.1.0:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/slash/-/slash-5.1.0.tgz#be3adddcdf09ac38eebe8dcdc7b1a57a75b095ce"
-  integrity sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg==
-
 slice-ansi@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-5.0.0.tgz#b73063c57aa96f9cd881654b15294d95d285c42a"
@@ -7213,6 +7180,14 @@ thunky@^1.0.2:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/thunky/-/thunky-1.1.0.tgz#5abaf714a9405db0504732bbccd2cedd9ef9537d"
 
+tinyglobby@^0.2.12:
+  version "0.2.12"
+  resolved "https://registry.yarnpkg.com/tinyglobby/-/tinyglobby-0.2.12.tgz#ac941a42e0c5773bd0b5d08f32de82e74a1a61b5"
+  integrity sha512-qkf4trmKSIiMTs/E63cxH+ojC2unam7rJ0WrauAzpT3ECNTxGRMlaXxVbfxMUC/w0LaYk6jQ4y/nGR9uBO3tww==
+  dependencies:
+    fdir "^6.4.3"
+    picomatch "^4.0.2"
+
 tmp@^0.2.3:
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.2.3.tgz#eb783cc22bc1e8bebd0671476d46ea4eb32a79ae"
@@ -7479,11 +7454,6 @@ unicode-match-property-value-ecmascript@^2.1.0:
 unicode-property-aliases-ecmascript@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-2.1.0.tgz#43d41e3be698bd493ef911077c9b131f827e8ccd"
-
-unicorn-magic@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/unicorn-magic/-/unicorn-magic-0.1.0.tgz#1bb9a51c823aaf9d73a8bfcd3d1a23dde94b0ce4"
-  integrity sha512-lRfVq8fE8gz6QMBuDM6a+LO3IAzTi05H6gCVaUpir2E1Rwpo4ZUog45KpNXKC/Mn3Yb9UDuHumeFTo9iV/D9FQ==
 
 universalify@^0.2.0:
   version "0.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7177,9 +7177,9 @@ tapable@^2.0.0, tapable@^2.1.1, tapable@^2.2.0:
   resolved "https://registry.yarnpkg.com/tapable/-/tapable-2.2.1.tgz#1967a73ef4060a82f12ab96af86d52fdb76eeca0"
 
 terser-webpack-plugin@^5.3.10, terser-webpack-plugin@^5.3.11:
-  version "5.3.11"
-  resolved "https://registry.yarnpkg.com/terser-webpack-plugin/-/terser-webpack-plugin-5.3.11.tgz#93c21f44ca86634257cac176f884f942b7ba3832"
-  integrity sha512-RVCsMfuD0+cTt3EwX8hSl2Ks56EbFHWmhluwcqoPKtBnfjiT6olaq7PRIRfhyU8nnC2MrnDrBLfrD/RGE+cVXQ==
+  version "5.3.12"
+  resolved "https://registry.yarnpkg.com/terser-webpack-plugin/-/terser-webpack-plugin-5.3.12.tgz#d9518c80493081bace668aa8613b22e4a838810c"
+  integrity sha512-jDLYqo7oF8tJIttjXO6jBY5Hk8p3A8W4ttih7cCEq64fQFWmgJ4VqAQjKr7WwIDlmXKEc6QeoRb5ecjZ+2afcg==
   dependencies:
     "@jridgewell/trace-mapping" "^0.3.25"
     jest-worker "^27.4.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3448,10 +3448,10 @@ eslint-config-airbnb@^19.0.4:
     object.assign "^4.1.2"
     object.entries "^1.1.5"
 
-eslint-config-prettier@^9.1.0:
-  version "9.1.0"
-  resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-9.1.0.tgz#31af3d94578645966c082fcb71a5846d3c94867f"
-  integrity sha512-NSWl5BFQWEPi1j4TjVNItzYV7dZXZ+wP6I6ZhrBGpChQhZRUaElihE9uRRkcbRnNb76UMKDF3r+WTmNcGPKsqw==
+eslint-config-prettier@^10.0.1:
+  version "10.0.1"
+  resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-10.0.1.tgz#fbb03bfc8db0651df9ce4e8b7150d11c5fe3addf"
+  integrity sha512-lZBts941cyJyeaooiKxAtzoPHTN+GbQTJFAIdQbRhA4/8whaAraEh47Whw/ZFfrjNSnlAxqfm9i0XVAEkULjCw==
 
 eslint-import-resolver-node@^0.3.9:
   version "0.3.9"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6133,9 +6133,9 @@ prelude-ls@~1.1.2:
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
 
 prettier@^3.2.5:
-  version "3.4.2"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-3.4.2.tgz#a5ce1fb522a588bf2b78ca44c6e6fe5aa5a2b13f"
-  integrity sha512-e9MewbtFo+Fevyuxn/4rrcDAaq0IYxPGLvObpQjiZBMAzB9IGmzlnG9RZy3FFas+eBMu2vA0CszMeduow5dIuQ==
+  version "3.5.2"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-3.5.2.tgz#d066c6053200da0234bf8fa1ef45168abed8b914"
+  integrity sha512-lc6npv5PH7hVqozBR7lkBNOGXV9vMwROAPlumdBkX0wTbbzPu/U1hk5yL8p2pt4Xoc+2mkT8t/sow2YrV/M5qg==
 
 pretty-error@^4.0.0:
   version "4.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1131,6 +1131,11 @@
     "@babel/helper-string-parser" "^7.25.9"
     "@babel/helper-validator-identifier" "^7.25.9"
 
+"@bazel/runfiles@^6.3.1":
+  version "6.3.1"
+  resolved "https://registry.yarnpkg.com/@bazel/runfiles/-/runfiles-6.3.1.tgz#3f8824b2d82853377799d42354b4df78ab0ace0b"
+  integrity sha512-1uLNT5NZsUVIGS4syuHwTzZ8HycMPyr6POA3FCE4GbMtc4rhoJk8aZKtNIRthJYfL+iioppi+rTfH3olMPr9nA==
+
 "@bcoe/v8-coverage@^0.2.3":
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
@@ -3074,20 +3079,21 @@ ecc-jsbn@~0.1.1:
     jsbn "~0.1.0"
     safer-buffer "^2.1.0"
 
-echarts-gl@^2.0.8:
+echarts-gl@^2.0.9:
   version "2.0.9"
   resolved "https://registry.yarnpkg.com/echarts-gl/-/echarts-gl-2.0.9.tgz#ee228a6c7520a6fb7bbb71ea94394f3637ade033"
+  integrity sha512-oKeMdkkkpJGWOzjgZUsF41DOh6cMsyrGGXimbjK2l6Xeq/dBQu4ShG2w2Dzrs/1bD27b2pLTGSaUzouY191gzA==
   dependencies:
     claygl "^1.2.1"
     zrender "^5.1.1"
 
-echarts@^5.3.3:
-  version "5.4.3"
-  resolved "https://registry.yarnpkg.com/echarts/-/echarts-5.4.3.tgz#f5522ef24419164903eedcfd2b506c6fc91fb20c"
-  integrity sha512-mYKxLxhzy6zyTi/FaEbJMOZU1ULGEQHaeIeuMR5L+JnJTpz+YR03mnnpBhbR4+UYJAgiXgpyTVLffPAjOTLkZA==
+echarts@^5.6.0:
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/echarts/-/echarts-5.6.0.tgz#2377874dca9fb50f104051c3553544752da3c9d6"
+  integrity sha512-oTbVTsXfKuEhxftHqL5xprgLoc0k7uScAwtryCgWF6hPYFLRwOUHiFmHGCBKP5NPFNkDVopOieyUqYGH8Fa3kA==
   dependencies:
     tslib "2.3.0"
-    zrender "5.4.4"
+    zrender "5.6.1"
 
 ee-first@1.1.1:
   version "1.1.1"
@@ -4340,6 +4346,11 @@ ignore@^5.2.0, ignore@^5.2.4:
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.3.1.tgz#5073e554cd42c5b33b394375f538b8593e34d4ef"
   integrity sha512-5Fytz/IraMjqpwfd34ke28PTVMjZjJG2MPn5t7OE4eUCUNf8BAa7b5WUS9/Qvr6mwOQS7Mk6vdsMno5he+T8Xw==
 
+immediate@~3.0.5:
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/immediate/-/immediate-3.0.6.tgz#9db1dbd0faf8de6fbe0f5dd5e56bb606280de69b"
+  integrity sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==
+
 import-fresh@^3.2.1:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/import-fresh/-/import-fresh-3.3.0.tgz#37162c25fcb9ebaa2e6e53d5b4d88ce17d9e0c2b"
@@ -4369,7 +4380,7 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2, inherits@2.0.4, inherits@^2.0.1, inherits@^2.0.3, inherits@~2.0.1:
+inherits@2, inherits@2.0.4, inherits@^2.0.1, inherits@^2.0.3, inherits@~2.0.1, inherits@~2.0.3:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
 
@@ -5332,6 +5343,16 @@ jsprim@^1.2.2:
     object.assign "^4.1.4"
     object.values "^1.1.6"
 
+jszip@^3.10.1:
+  version "3.10.1"
+  resolved "https://registry.yarnpkg.com/jszip/-/jszip-3.10.1.tgz#34aee70eb18ea1faec2f589208a157d1feb091c2"
+  integrity sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==
+  dependencies:
+    lie "~3.3.0"
+    pako "~1.0.2"
+    readable-stream "~2.3.6"
+    setimmediate "^1.0.5"
+
 kdbush@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/kdbush/-/kdbush-4.0.2.tgz#2f7b7246328b4657dd122b6c7f025fbc2c868e39"
@@ -5393,6 +5414,13 @@ levn@~0.3.0:
   dependencies:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
+
+lie@~3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/lie/-/lie-3.3.0.tgz#dcf82dee545f46074daf200c7c1c5a08e0f40f6a"
+  integrity sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==
+  dependencies:
+    immediate "~3.0.5"
 
 lilconfig@^3.1.3:
   version "3.1.3"
@@ -5875,6 +5903,11 @@ p-try@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/p-try/-/p-try-2.2.0.tgz#cb2868540e313d61de58fafbe35ce9004d5540e6"
 
+pako@~1.0.2:
+  version "1.0.11"
+  resolved "https://registry.yarnpkg.com/pako/-/pako-1.0.11.tgz#6c9599d340d54dfd3946380252a35705a6b992bf"
+  integrity sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==
+
 param-case@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/param-case/-/param-case-3.0.4.tgz#7d17fe4aa12bde34d4a77d91acfb6219caad01c5"
@@ -6062,6 +6095,11 @@ process-nextick-args@~1.0.6:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-1.0.7.tgz#150e20b756590ad3f91093f25a4f2ad8bff30ba3"
 
+process-nextick-args@~2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.1.tgz#7820d9b16120cc55ca9ae7792680ae7dba6d7fe2"
+  integrity sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==
+
 prompts@^2.0.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/prompts/-/prompts-2.2.1.tgz#f901dd2a2dfee080359c0e20059b24188d75ad35"
@@ -6163,6 +6201,19 @@ readable-stream@^3.0.6:
     inherits "^2.0.3"
     string_decoder "^1.1.1"
     util-deprecate "^1.0.1"
+
+readable-stream@~2.3.6:
+  version "2.3.8"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.8.tgz#91125e8042bba1b9887f49345f6277027ce8be9b"
+  integrity sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==
+  dependencies:
+    core-util-is "~1.0.0"
+    inherits "~2.0.3"
+    isarray "~1.0.0"
+    process-nextick-args "~2.0.0"
+    safe-buffer "~5.1.1"
+    string_decoder "~1.1.1"
+    util-deprecate "~1.0.1"
 
 readdirp@~3.6.0:
   version "3.6.0"
@@ -6444,7 +6495,7 @@ safe-array-concat@^1.1.3:
     has-symbols "^1.1.0"
     isarray "^2.0.5"
 
-safe-buffer@5.1.2:
+safe-buffer@5.1.2, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
 
@@ -6510,6 +6561,16 @@ schema-utils@^4.0.0, schema-utils@^4.2.0, schema-utils@^4.3.0:
 select-hose@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/select-hose/-/select-hose-2.0.0.tgz#625d8658f865af43ec962bfc376a37359a4994ca"
+
+selenium-webdriver@^4.29.0:
+  version "4.29.0"
+  resolved "https://registry.yarnpkg.com/selenium-webdriver/-/selenium-webdriver-4.29.0.tgz#32d32fb60df488bbc399b9dd58728a5cd570210e"
+  integrity sha512-8XPGtDoji5xk7ZUCzFT1rqHmCp67DCzESsttId7DzmrJmlTRmRLF6X918rbwclcH89amcBNM4zB3lVPj404I0g==
+  dependencies:
+    "@bazel/runfiles" "^6.3.1"
+    jszip "^3.10.1"
+    tmp "^0.2.3"
+    ws "^8.18.0"
 
 selfsigned@^2.4.1:
   version "2.4.1"
@@ -6620,6 +6681,11 @@ set-function-name@^2.0.2:
     es-errors "^1.3.0"
     functions-have-names "^1.2.3"
     has-property-descriptors "^1.0.2"
+
+setimmediate@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/setimmediate/-/setimmediate-1.0.5.tgz#290cbb232e306942d7d7ea9b83732ab7856f8285"
+  integrity sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==
 
 setprototypeof@1.1.0:
   version "1.1.0"
@@ -6974,6 +7040,13 @@ string_decoder@~1.0.0:
   dependencies:
     safe-buffer "^5.0.1"
 
+string_decoder@~1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.1.1.tgz#9cf1611ba62685d7030ae9e4ba34149c3af03fc8"
+  integrity sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==
+  dependencies:
+    safe-buffer "~5.1.0"
+
 strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
@@ -7085,6 +7158,11 @@ text-table@^0.2.0:
 thunky@^1.0.2:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/thunky/-/thunky-1.1.0.tgz#5abaf714a9405db0504732bbccd2cedd9ef9537d"
+
+tmp@^0.2.3:
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.2.3.tgz#eb783cc22bc1e8bebd0671476d46ea4eb32a79ae"
+  integrity sha512-nZD7m9iCPC5g0pYmcaxogYKggSfLsdxl8of3Q/oIbqCqLLIO9IAF0GWjX1z9NZRHPiXv8Wex4yDCaZsgEw0Y8w==
 
 tmpl@1.0.5:
   version "1.0.5"
@@ -7765,14 +7843,7 @@ yocto-queue@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-0.1.0.tgz#0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b"
 
-zrender@5.4.4:
-  version "5.4.4"
-  resolved "https://registry.yarnpkg.com/zrender/-/zrender-5.4.4.tgz#8854f1d95ecc82cf8912f5a11f86657cb8c9e261"
-  integrity sha512-0VxCNJ7AGOMCWeHVyTrGzUgrK4asT4ml9PEkeGirAkKNYXYzoPJCLvmyfdoOXcjTHPs10OZVMfD1Rwg16AZyYw==
-  dependencies:
-    tslib "2.3.0"
-
-zrender@^5.1.1, zrender@^5.3.2:
+zrender@5.6.1, zrender@^5.1.1, zrender@^5.6.1:
   version "5.6.1"
   resolved "https://registry.yarnpkg.com/zrender/-/zrender-5.6.1.tgz#e08d57ecf4acac708c4fcb7481eb201df7f10a6b"
   integrity sha512-OFXkDJKcrlx5su2XbzJvj/34Q3m6PvyCZkVPHGYpcCJ52ek4U/ymZyfuV1nKE23AyBJ51E/6Yr0mhZ7xGTO4ag==

--- a/yarn.lock
+++ b/yarn.lock
@@ -3512,9 +3512,9 @@ eslint-config-airbnb@^19.0.4:
     object.entries "^1.1.5"
 
 eslint-config-prettier@^10.0.1:
-  version "10.0.1"
-  resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-10.0.1.tgz#fbb03bfc8db0651df9ce4e8b7150d11c5fe3addf"
-  integrity sha512-lZBts941cyJyeaooiKxAtzoPHTN+GbQTJFAIdQbRhA4/8whaAraEh47Whw/ZFfrjNSnlAxqfm9i0XVAEkULjCw==
+  version "10.0.2"
+  resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-10.0.2.tgz#47444de8aa104ce82c2f91ad2a5e96b62c01e20d"
+  integrity sha512-1105/17ZIMjmCOJOPNfVdbXafLCLj3hPmkmB7dLgt7XsQ/zkxSuDerE/xgO3RxoHysR1N1whmquY0lSn2O0VLg==
 
 eslint-import-resolver-node@^0.3.9:
   version "0.3.9"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1725,7 +1725,7 @@
     "@types/tough-cookie" "*"
     parse5 "^7.0.0"
 
-"@types/json-schema@*", "@types/json-schema@^7.0.8", "@types/json-schema@^7.0.9":
+"@types/json-schema@*", "@types/json-schema@^7.0.9":
   version "7.0.11"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.11.tgz#d421b6c527a3037f7c84433fd2c4229e016863d3"
 
@@ -2016,17 +2016,13 @@ ajv-formats@^2.1.1:
   dependencies:
     ajv "^8.0.0"
 
-ajv-keywords@^3.5.2:
-  version "3.5.2"
-  resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-3.5.2.tgz#31f29da5ab6e00d1c2d329acf7b5929614d5014d"
-
 ajv-keywords@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-5.1.0.tgz#69d4d385a4733cdbeab44964a1170a88f87f0e16"
   dependencies:
     fast-deep-equal "^3.1.3"
 
-ajv@^6.12.3, ajv@^6.12.4, ajv@^6.12.5:
+ajv@^6.12.3, ajv@^6.12.4:
   version "6.12.6"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.6.tgz#baf5a62e802b07d977034586f8c3baf5adf26df4"
   dependencies:
@@ -6606,14 +6602,6 @@ saxes@^6.0.0:
   dependencies:
     xmlchars "^2.2.0"
 
-schema-utils@^3.2.0:
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/schema-utils/-/schema-utils-3.3.0.tgz#f50a88877c3c01652a15b622ae9e9795df7a60fe"
-  dependencies:
-    "@types/json-schema" "^7.0.8"
-    ajv "^6.12.5"
-    ajv-keywords "^3.5.2"
-
 schema-utils@^4.0.0, schema-utils@^4.2.0, schema-utils@^4.3.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/schema-utils/-/schema-utils-4.3.0.tgz#3b669f04f71ff2dfb5aba7ce2d5a9d79b35622c0"
@@ -7188,7 +7176,7 @@ tapable@^2.0.0, tapable@^2.1.1, tapable@^2.2.0:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/tapable/-/tapable-2.2.1.tgz#1967a73ef4060a82f12ab96af86d52fdb76eeca0"
 
-terser-webpack-plugin@^5.3.10:
+terser-webpack-plugin@^5.3.10, terser-webpack-plugin@^5.3.11:
   version "5.3.11"
   resolved "https://registry.yarnpkg.com/terser-webpack-plugin/-/terser-webpack-plugin-5.3.11.tgz#93c21f44ca86634257cac176f884f942b7ba3832"
   integrity sha512-RVCsMfuD0+cTt3EwX8hSl2Ks56EbFHWmhluwcqoPKtBnfjiT6olaq7PRIRfhyU8nnC2MrnDrBLfrD/RGE+cVXQ==
@@ -7673,9 +7661,9 @@ webpack-sources@^3.2.3:
   resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-3.2.3.tgz#2d4daab8451fd4b240cc27055ff6a0c2ccea0cde"
 
 webpack@^5.90.3:
-  version "5.97.1"
-  resolved "https://registry.yarnpkg.com/webpack/-/webpack-5.97.1.tgz#972a8320a438b56ff0f1d94ade9e82eac155fa58"
-  integrity sha512-EksG6gFY3L1eFMROS/7Wzgrii5mBAFe4rIr3r2BTfo7bcc+DWwFZ4OJ/miOuHJO/A85HwyI4eQ0F6IKXesO7Fg==
+  version "5.98.0"
+  resolved "https://registry.yarnpkg.com/webpack/-/webpack-5.98.0.tgz#44ae19a8f2ba97537978246072fb89d10d1fbd17"
+  integrity sha512-UFynvx+gM44Gv9qFgj0acCQK2VE1CtdfwFdimkapco3hlPCJ/zeq73n2yVKimVbtm+TnApIugGhLJnkU6gjYXA==
   dependencies:
     "@types/eslint-scope" "^3.7.7"
     "@types/estree" "^1.0.6"
@@ -7695,9 +7683,9 @@ webpack@^5.90.3:
     loader-runner "^4.2.0"
     mime-types "^2.1.27"
     neo-async "^2.6.2"
-    schema-utils "^3.2.0"
+    schema-utils "^4.3.0"
     tapable "^2.1.1"
-    terser-webpack-plugin "^5.3.10"
+    terser-webpack-plugin "^5.3.11"
     watchpack "^2.4.1"
     webpack-sources "^3.2.3"
 


### PR DESCRIPTION
## Checklist

- [X] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [X] I have manually tested the changes proposed in this pull request.
- [ ] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [ ] I have updated the documentation.

## Reference to Existing Issue

Closes #303 .

## Description of Changes

The initial issue was that CSS styles were being applied globally using the * selector, which can cause conflicts in larger projects. Here's how I fixed it:

Created a scoped container structure:
- Added .netjsongraph-container as main wrapper
- Added #graphChartContainer for the graph content
- This contains styles to just these elements instead of affecting entire page

- Fixed height/positioning issue:
- Set proper html/body height to 100%
- Made container absolute positioned with full dimensions
This ensures graph fills available space correctly

Updated JavaScript:
- Changed graph initialization to target specific container
- This connects the new DOM structure to the graph rendering

This approach prevents style leaks while maintaining the original functionality.

@pandafy @nemesifier  please review this pull request.
I have made appropriate changes to fix the issue.
