### PR TITLE
Fix: Restrict Map Zoom Levels to Supported Range

### DIFF
--- a/examples/load_data_geo_extent/index.html
+++ b/examples/load_data_geo_extent/index.html
@@ -73,7 +73,7 @@
       const map = new NetJSONGraph("http://localhost:3000/api/data/?page=1", {
         render: "map",
         // set map initial state.
-        
+        maxPointsFetched: 35,
         mapOptions: {
           center: [46.86764405052012, 19.675998687744144],
           zoom: 5,

--- a/examples/load_data_geo_extent/index.html
+++ b/examples/load_data_geo_extent/index.html
@@ -72,11 +72,13 @@
     <script type="text/javascript">
       const map = new NetJSONGraph("http://localhost:3000/api/data/?page=1", {
         render: "map",
-        maxPointsFetched: 35,
         // set map initial state.
+        
         mapOptions: {
           center: [46.86764405052012, 19.675998687744144],
           zoom: 5,
+          maxZoom: 18,
+          zoomControl: true,
           nodeConfig: {
             label: {
               offset: [0, -10],

--- a/src/js/netjsongraph.config.js
+++ b/src/js/netjsongraph.config.js
@@ -238,7 +238,7 @@ const NetJSONGraphDefaultConfig = {
         "http://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png",
       options: {
         minZoom: 3,
-        maxZoom: 32,
+        maxZoom: 18,
         attribution: `&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors,
          tiles offered by <a href="https://www.mapbox.com">Mapbox</a>`,
       },

--- a/src/js/netjsongraph.config.js
+++ b/src/js/netjsongraph.config.js
@@ -1,3 +1,5 @@
+import { max } from "zrender/lib/core/vector";
+
 /**
  * Default options
  *
@@ -33,6 +35,8 @@ const NetJSONGraphDefaultConfig = {
   svgRender: false,
   switchMode: false,
   maxPointsFetched: 10000,
+  maxZoom : 18,
+  minZoom : 3,
   loadMoreAtZoomLevel: 9,
   clustering: false,
   clusteringThreshold: 100,
@@ -161,6 +165,7 @@ const NetJSONGraphDefaultConfig = {
   mapOptions: {
     roam: true,
     zoomAnimation: false,
+    maxZoom: 18,
     nodeConfig: {
       type: "scatter",
       label: {

--- a/src/js/netjsongraph.config.js
+++ b/src/js/netjsongraph.config.js
@@ -1,5 +1,3 @@
-import { max } from "zrender/lib/core/vector";
-
 /**
  * Default options
  *

--- a/src/js/netjsongraph.render.js
+++ b/src/js/netjsongraph.render.js
@@ -14,6 +14,7 @@ import "leaflet.markercluster/dist/MarkerCluster.Default.css";
 import "zrender/lib/svg/svg";
 
 import "../../lib/js/echarts-gl.min";
+import { max } from "zrender/lib/core/vector";
 
 class NetJSONGraphRender {
   /**
@@ -270,7 +271,7 @@ class NetJSONGraphRender {
     return {
       leaflet: {
         tiles: configs.mapTileConfig,
-        mapOptions: configs.mapOptions,
+        mapOptions: {...configs.mapOptions , maxZoom : configs.maxZoom },
       },
       series,
       ...configs.mapOptions.baseOptions,
@@ -596,6 +597,19 @@ class NetJSONGraphRender {
           self.leaflet.setView([params.data.value[1], params.data.value[0]]);
         }
       });
+
+
+      self.leaflet = self.echarts._api.getCoordinateSystems()[0].getLeaflet();
+      self.leaflet._zoomAnimated = false;
+  
+      self.leaflet.options.maxZoom = self.config.maxZoomLevel; 
+  
+      self.leaflet.on("zoomend", () => {
+        if (self.leaflet.getZoom() > self.config.maxZoomLevel) {
+          self.leaflet.setZoom(self.config.maxZoomLevel);
+        }
+      });
+  
 
       self.leaflet.on("zoomend", () => {
         if (self.leaflet.getZoom() < self.config.disableClusteringAtLevel) {

--- a/src/js/netjsongraph.render.js
+++ b/src/js/netjsongraph.render.js
@@ -14,7 +14,6 @@ import "leaflet.markercluster/dist/MarkerCluster.Default.css";
 import "zrender/lib/svg/svg";
 
 import "../../lib/js/echarts-gl.min";
-import { max } from "zrender/lib/core/vector";
 
 class NetJSONGraphRender {
   /**


### PR DESCRIPTION
## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- [ ] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [ ] I have updated the documentation.

## Reference to Existing Issue

Closes #188  

## Description of Changes

earlier the max zoom was 32 by default , now it's reduced to 18 for better viewing experience

