### PR TITLE
[deps] Update ECharts to version 5.6.0 #305

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,22 @@ jobs:
         run: |
           yarn install
 
+      - name: Running Server
+        run: yarn start &
+
+      - name: Wait for server to be ready
+        run: npx wait-on http://localhost:8080
+
+      - name: Setup Chrome and ChromeDriver
+        uses: browser-actions/setup-chrome@v1
+
+      - name: Check chrome and chromedriver version
+        run: |
+          chrome --version
+          which chrome
+          chromedriver --version
+          which chromedriver
+
       - name: Tests
         run: yarn coverage
 

--- a/README.md
+++ b/README.md
@@ -24,17 +24,19 @@ yarn start
 ### Run Tests
 
 ```
+yarn start &  # or alternatively run this in a separate terminal
 yarn test
-
 ```
 
-To run a specific test suit
+To run a specific test suite:
 
 ```
 yarn test test/netjsongraph.browser.test.js
 ```
 
-The test suite includes browser tests. Ensure that ChromeDriver is installed and the server runs in a separate terminal.
+The test suite includes browser tests.
+
+Ensure that ChromeDriver is installed.
 
 ### Arguments
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,21 @@ yarn install
 yarn start
 ```
 
+### Run Tests
+
+```
+yarn test
+
+```
+
+To run a specific test suit
+
+```
+yarn test test/netjsongraph.browser.test.js
+```
+
+The test suite includes browser tests. Ensure that ChromeDriver is installed and the server runs in a separate terminal.
+
 ### Arguments
 
 netjsongraph.js accepts two arguments.

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "jest-environment-jsdom": "^29.7.0",
     "lint-staged": "^15.2.2",
     "prettier": "^3.2.5",
+    "selenium-webdriver": "^4.29.0",
     "style-loader": "^4.0.0",
     "terser-webpack-plugin": "^5.3.10",
     "webpack": "^5.90.3",
@@ -80,7 +81,6 @@
     "kdbush": "^4.0.2",
     "leaflet": "^1.8.0",
     "leaflet.markercluster": "^1.5.3",
-    "selenium-webdriver": "^4.29.0",
     "zrender": "^5.6.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -31,7 +31,10 @@
     "globalSetup": "./jest.global-setup.js",
     "moduleNameMapper": {
       "\\.(css)$": "identity-obj-proxy"
-    }
+    },
+    "coveragePathIgnorePatterns": [
+      "test/"
+    ]
   },
   "repository": "https://github.com/netjson/netjsongraph.js.git",
   "author": "Federico Capoano <f.capoano@openwisp.io> (https://openwisp.io)",

--- a/package.json
+++ b/package.json
@@ -75,11 +75,12 @@
     "webpack-dev-server": "^5.0.2"
   },
   "dependencies": {
-    "echarts": "^5.3.3",
-    "echarts-gl": "^2.0.8",
+    "echarts": "^5.6.0",
+    "echarts-gl": "^2.0.9",
     "kdbush": "^4.0.2",
     "leaflet": "^1.8.0",
     "leaflet.markercluster": "^1.5.3",
-    "zrender": "^5.3.2"
+    "selenium-webdriver": "^4.29.0",
+    "zrender": "^5.6.1"
   }
 }

--- a/src/js/netjsongraph.render.js
+++ b/src/js/netjsongraph.render.js
@@ -1,19 +1,35 @@
-import * as echarts from "echarts/lib/echarts";
-import "echarts/lib/chart/graph";
-import "echarts/lib/chart/effectScatter";
-import "echarts/lib/chart/lines";
-import "echarts/lib/component/tooltip";
-import "echarts/lib/component/title";
-import "echarts/lib/component/toolbox";
-import "echarts/lib/component/legend";
+import * as echarts from "echarts/core";
+import {
+  GraphChart,
+  EffectScatterChart,
+  LinesChart,
+  ScatterChart,
+} from "echarts/charts";
+import {
+  TooltipComponent,
+  TitleComponent,
+  ToolboxComponent,
+  LegendComponent,
+} from "echarts/components";
+import {SVGRenderer} from "echarts/renderers";
 import L from "leaflet/dist/leaflet";
 import "leaflet.markercluster";
 import "leaflet.markercluster/dist/MarkerCluster.css";
 import "leaflet.markercluster/dist/MarkerCluster.Default.css";
 
-import "zrender/lib/svg/svg";
+import "echarts-gl";
 
-import "../../lib/js/echarts-gl.min";
+echarts.use([
+  GraphChart,
+  EffectScatterChart,
+  LinesChart,
+  TooltipComponent,
+  TitleComponent,
+  ToolboxComponent,
+  LegendComponent,
+  SVGRenderer,
+  ScatterChart,
+]);
 
 class NetJSONGraphRender {
   /**
@@ -56,7 +72,7 @@ class NetJSONGraphRender {
           },
           padding: [5, 12],
           textStyle: {
-            lineHeight: 5,
+            lineHeight: 20,
           },
           renderMode: "html",
           className: "njg-tooltip",

--- a/test/browser.test.utils.js
+++ b/test/browser.test.utils.js
@@ -2,7 +2,7 @@ import {Builder, By, until} from "selenium-webdriver";
 import chrome from "selenium-webdriver/chrome";
 import graphData from "../public/assets/data/netjsonmap.json";
 
-const url = "http://localhost:8080/";
+const url = "http://0.0.0.0:8080";
 
 export const getDriver = async () => {
   try {
@@ -10,8 +10,6 @@ export const getDriver = async () => {
       .forBrowser("chrome")
       .setChromeOptions(new chrome.Options().addArguments("--headless"))
       .build();
-
-    await driver.get(url);
     return driver;
   } catch (err) {
     console.error("Failed to initialize driver:", err);
@@ -19,12 +17,9 @@ export const getDriver = async () => {
   }
 };
 
-export const openExample = async (driver, example) => {
-  await driver
-    .findElement(By.xpath(`//div[@class='cards']//a[text()='${example}']`))
-    .click();
-  const tabs = await driver.getAllWindowHandles();
-  await driver.switchTo().window(tabs[1]);
+export const urls = {
+  basicUsage: `${url}/examples/netjsongraph.html`,
+  geographicMap: `${url}/examples/netjsonmap.html`,
 };
 
 export const getElementByCss = async (driver, css, waitTime = 1000) => {
@@ -45,7 +40,7 @@ export const getElementsByCss = async (driver, css, waitTime = 1000) => {
   }
 };
 
-export const getRenderedNodesAndLinks = async (driver) => {
+export const getRenderedNodesAndLinksCount = async (driver) => {
   try {
     const nodes = await driver.executeScript(`
       return document.querySelector('.njg-metaDataItems:nth-child(5) .njg-valueLabel').textContent;
@@ -63,9 +58,11 @@ export const getRenderedNodesAndLinks = async (driver) => {
   }
 };
 
-export const getPresentNodesAndLinks = async (example) => {
+export const getPresentNodesAndLinksCount = async (example) => {
   let data;
-  if (example === "Geographic map") {
+  if (example === "Basic usage") {
+    data = graphData;
+  } else if (example === "Geographic map") {
     data = graphData;
   }
   return {nodesPresent: data.nodes.length, linksPresent: data.links.length};
@@ -81,14 +78,12 @@ export const captureConsoleErrors = async (driver) => {
 
 export const tearDown = async (driver) => {
   const consoleErrors = await captureConsoleErrors(driver);
-
   if (consoleErrors.length > 0) {
     console.error("Console Errors Detected:");
     consoleErrors.forEach((error) =>
       console.error(`${error.level.name}: ${error.message}`),
     );
   }
-
   await driver.executeScript("window.sessionStorage.clear()");
   await driver.executeScript("window.localStorage.clear()");
   await driver.manage().deleteAllCookies();

--- a/test/browser.test.utils.js
+++ b/test/browser.test.utils.js
@@ -1,6 +1,18 @@
 import {Builder, By, until} from "selenium-webdriver";
 import chrome from "selenium-webdriver/chrome";
-import graphData from "../public/assets/data/netjsonmap.json";
+import netJsonMap from "../public/assets/data/netjsonmap.json";
+import netJsonMultipleInterfaces from "../public/assets/data/netjson-multipleInterfaces.json";
+import netJsonGraphFoldNodes from "../public/assets/data/netjsongraph-foldNodes.json";
+import netJsonMapIndoorMap from "../public/assets/data/netjsonmap-indoormap.json";
+import netJsonGraphGraphGL from "../public/assets/data/netjsongraph-graphGL.json";
+import netJsonElementsLegend from "../public/assets/data/netjson-elementsLegend.json";
+import netJsonGraphMultipleLinks from "../public/assets/data/netjsongraph-multipleLinks.json";
+import airplaneRouteMap from "../public/assets/data/airplaneRouteMap.json";
+import geoJsonSample from "../public/assets/data/geojson-sample.json";
+import netJsonNodeTiles1 from "../public/assets/data/netjsonNodeTiles/1.json";
+import netJsonAppendData1 from "../public/assets/data/netjsonAppendData/1.json";
+import netJsonAppendData2 from "../public/assets/data/netjsonAppendData/2.json";
+import netJsonAppendData3 from "../public/assets/data/netjsonAppendData/3.json";
 
 const url = "http://0.0.0.0:8080";
 
@@ -59,12 +71,44 @@ export const getRenderedNodesAndLinksCount = async (driver) => {
 };
 
 export const getPresentNodesAndLinksCount = async (example) => {
-  let data;
-  if (example === "Basic usage") {
-    data = graphData;
-  } else if (example === "Geographic map") {
-    data = graphData;
+  const mapping = {
+    "Basic usage": netJsonMap,
+    "Geographic map": netJsonMap,
+    "Multiple interfaces": netJsonMultipleInterfaces,
+    "Search elements": netJsonMap,
+    "Data parse": netJsonMap,
+    "Switch render mode": netJsonMap,
+    "Switch graph mode": netJsonMap,
+    "Nodes expand or fold": netJsonGraphFoldNodes,
+    "Indoor map": netJsonMapIndoorMap,
+    "Leaflet plugins": netJsonMap,
+    "GraphGL render for big data": netJsonGraphGraphGL,
+    "Custom attributes": netJsonElementsLegend,
+    "Multiple links render": netJsonGraphMultipleLinks,
+    "JSONDataUpdate using override option": netJsonNodeTiles1,
+    "JSONDataUpdate using append option": netJsonAppendData1,
+    "Multiple tiles render": netJsonMap,
+    "Geographic map animated links": airplaneRouteMap,
+    "Append data using arrays": {
+      ...netJsonAppendData1,
+      nodes: [
+        ...netJsonAppendData1.nodes,
+        ...netJsonAppendData2.nodes,
+        ...netJsonAppendData3.nodes,
+      ],
+      links: [
+        ...netJsonAppendData1.links,
+        ...netJsonAppendData2.links,
+        ...netJsonAppendData3.links,
+      ],
+    },
+    "Geographic map with GeoJSON data": geoJsonSample,
+    Clustering: netJsonMap,
+  };
+  if (!(example in mapping)) {
+    throw new Error("Invalid example type");
   }
+  const data = mapping[example];
   return {nodesPresent: data.nodes.length, linksPresent: data.links.length};
 };
 

--- a/test/browser.test.utils.js
+++ b/test/browser.test.utils.js
@@ -18,13 +18,10 @@ const url = "http://0.0.0.0:8080";
 
 export const getDriver = async () => {
   try {
-    let options = new chrome.Options();
-    options.addArguments("--headless")
-    options.addArguments("--remote-debugging-pipe");
-    return new Builder()
-      .forBrowser("chrome")
-      .setChromeOptions(options)
-      .build();
+    const options = new chrome.Options();
+    options.addArguments("--headless");
+    options.addArguments("--remote-debugging-port=9222");
+    return new Builder().forBrowser("chrome").setChromeOptions(options).build();
   } catch (err) {
     console.error("Failed to initialize driver:", err);
     throw err;

--- a/test/browser.test.utils.js
+++ b/test/browser.test.utils.js
@@ -18,11 +18,13 @@ const url = "http://0.0.0.0:8080";
 
 export const getDriver = async () => {
   try {
-    const driver = new Builder()
+    let options = new chrome.Options();
+    options.addArguments("--headless")
+    options.addArguments("--remote-debugging-pipe");
+    return new Builder()
       .forBrowser("chrome")
-      .setChromeOptions(new chrome.Options().addArguments("--headless"))
+      .setChromeOptions(options)
       .build();
-    return driver;
   } catch (err) {
     console.error("Failed to initialize driver:", err);
     throw err;

--- a/test/browser.test.utils.js
+++ b/test/browser.test.utils.js
@@ -1,0 +1,96 @@
+import {Builder, By, until} from "selenium-webdriver";
+import chrome from "selenium-webdriver/chrome";
+import graphData from "../public/assets/data/netjsonmap.json";
+
+const url = "http://localhost:8080/";
+
+export const getDriver = async () => {
+  try {
+    const driver = new Builder()
+      .forBrowser("chrome")
+      .setChromeOptions(new chrome.Options().addArguments("--headless"))
+      .build();
+
+    await driver.get(url);
+    return driver;
+  } catch (err) {
+    console.error("Failed to initialize driver:", err);
+    throw err;
+  }
+};
+
+export const openExample = async (driver, example) => {
+  await driver
+    .findElement(By.xpath(`//div[@class='cards']//a[text()='${example}']`))
+    .click();
+  const tabs = await driver.getAllWindowHandles();
+  await driver.switchTo().window(tabs[1]);
+};
+
+export const getElementByCss = async (driver, css, waitTime = 1000) => {
+  try {
+    return await driver.wait(until.elementLocated(By.css(css)), waitTime);
+  } catch (err) {
+    console.error("Error finding element:", css, err);
+    return null;
+  }
+};
+
+export const getElementsByCss = async (driver, css, waitTime = 1000) => {
+  try {
+    return await driver.wait(until.elementsLocated(By.css(css)), waitTime);
+  } catch (err) {
+    console.error(`Error finding elements: ${css}`, err);
+    return [];
+  }
+};
+
+export const getRenderedNodesAndLinks = async (driver) => {
+  try {
+    const nodes = await driver.executeScript(`
+      return document.querySelector('.njg-metaDataItems:nth-child(5) .njg-valueLabel').textContent;
+    `);
+
+    const links = await driver.executeScript(`
+      return document.querySelector('.njg-metaDataItems:nth-child(6) .njg-valueLabel').textContent;
+    `);
+    const nodesRendered = parseInt(nodes, 10);
+    const linksRendered = parseInt(links, 10);
+    return {nodesRendered, linksRendered};
+  } catch (error) {
+    console.error("Error extracting nodes and links:", error);
+    return {nodesRendered: 0, linksRendered: 0};
+  }
+};
+
+export const getPresentNodesAndLinks = async (example) => {
+  let data;
+  if (example === "Geographic map") {
+    data = graphData;
+  }
+  return {nodesPresent: data.nodes.length, linksPresent: data.links.length};
+};
+
+export const captureConsoleErrors = async (driver) => {
+  const logs = await driver.manage().logs().get("browser");
+  return logs.filter(
+    (log) =>
+      log.level.name === "SEVERE" && !log.message.includes("favicon.ico"),
+  );
+};
+
+export const tearDown = async (driver) => {
+  const consoleErrors = await captureConsoleErrors(driver);
+
+  if (consoleErrors.length > 0) {
+    console.error("Console Errors Detected:");
+    consoleErrors.forEach((error) =>
+      console.error(`${error.level.name}: ${error.message}`),
+    );
+  }
+
+  await driver.executeScript("window.sessionStorage.clear()");
+  await driver.executeScript("window.localStorage.clear()");
+  await driver.manage().deleteAllCookies();
+  await driver.quit();
+};

--- a/test/netjsongraph.browser.test.js
+++ b/test/netjsongraph.browser.test.js
@@ -2,12 +2,14 @@ import {
   getElementByCss,
   tearDown,
   captureConsoleErrors,
-  openExample,
   getDriver,
   getElementsByCss,
-  getRenderedNodesAndLinks,
-  getPresentNodesAndLinks,
+  getRenderedNodesAndLinksCount,
+  getPresentNodesAndLinksCount,
+  urls,
 } from "./browser.test.utils";
+
+jest.setTimeout(20000);
 
 describe("Chart Rendering Test", () => {
   let driver;
@@ -20,21 +22,35 @@ describe("Chart Rendering Test", () => {
     await tearDown(driver);
   });
 
+  test("render the Basic usaage example without console errors", async () => {
+    driver.get(urls.basicUsage);
+    const canvas = await getElementByCss(driver, "canvas", 5000);
+    const consoleErrors = await captureConsoleErrors(driver);
+    const {nodesRendered, linksRendered} =
+      await getRenderedNodesAndLinksCount(driver);
+    const {nodesPresent, linksPresent} =
+      await getPresentNodesAndLinksCount("Geographic map");
+    expect(consoleErrors.length).toBe(0);
+    expect(canvas).not.toBeNull();
+    expect(nodesRendered).toBe(nodesPresent);
+    expect(linksRendered).toBe(linksPresent);
+  });
+
   test("render the Geographic map example without console errors", async () => {
-    await openExample(driver, "Geographic map");
+    driver.get(urls.geographicMap);
     const leafletContainer = await getElementByCss(
       driver,
       ".ec-extension-leaflet",
-      2000,
+      5000,
     );
     const canvases = await getElementsByCss(
       driver,
       ".ec-extension-leaflet .leaflet-overlay-pane canvas",
     );
     const {nodesRendered, linksRendered} =
-      await getRenderedNodesAndLinks(driver);
+      await getRenderedNodesAndLinksCount(driver);
     const {nodesPresent, linksPresent} =
-      await getPresentNodesAndLinks("Geographic map");
+      await getPresentNodesAndLinksCount("Geographic map");
     const consoleErrors = await captureConsoleErrors(driver);
     expect(consoleErrors.length).toBe(0);
     expect(leafletContainer).not.toBeNull();

--- a/test/netjsongraph.browser.test.js
+++ b/test/netjsongraph.browser.test.js
@@ -1,0 +1,45 @@
+import {
+  getElementByCss,
+  tearDown,
+  captureConsoleErrors,
+  openExample,
+  getDriver,
+  getElementsByCss,
+  getRenderedNodesAndLinks,
+  getPresentNodesAndLinks,
+} from "./browser.test.utils";
+
+describe("Chart Rendering Test", () => {
+  let driver;
+
+  beforeAll(async () => {
+    driver = await getDriver();
+  });
+
+  afterAll(async () => {
+    await tearDown(driver);
+  });
+
+  test("render the Geographic map example without console errors", async () => {
+    await openExample(driver, "Geographic map");
+    const leafletContainer = await getElementByCss(
+      driver,
+      ".ec-extension-leaflet",
+      2000,
+    );
+    const canvases = await getElementsByCss(
+      driver,
+      ".ec-extension-leaflet .leaflet-overlay-pane canvas",
+    );
+    const {nodesRendered, linksRendered} =
+      await getRenderedNodesAndLinks(driver);
+    const {nodesPresent, linksPresent} =
+      await getPresentNodesAndLinks("Geographic map");
+    const consoleErrors = await captureConsoleErrors(driver);
+    expect(consoleErrors.length).toBe(0);
+    expect(leafletContainer).not.toBeNull();
+    expect(canvases.length).toBeGreaterThan(0);
+    expect(nodesRendered).toBe(nodesPresent);
+    expect(linksRendered).toBe(linksPresent);
+  });
+});

--- a/test/netjsongraph.browser.test.js
+++ b/test/netjsongraph.browser.test.js
@@ -9,8 +9,6 @@ import {
   urls,
 } from "./browser.test.utils";
 
-jest.setTimeout(20000);
-
 describe("Chart Rendering Test", () => {
   let driver;
 
@@ -24,7 +22,7 @@ describe("Chart Rendering Test", () => {
 
   test("render the Basic usaage example without console errors", async () => {
     driver.get(urls.basicUsage);
-    const canvas = await getElementByCss(driver, "canvas", 5000);
+    const canvas = await getElementByCss(driver, "canvas", 2000);
     const consoleErrors = await captureConsoleErrors(driver);
     const {nodesRendered, linksRendered} =
       await getRenderedNodesAndLinksCount(driver);
@@ -41,7 +39,7 @@ describe("Chart Rendering Test", () => {
     const leafletContainer = await getElementByCss(
       driver,
       ".ec-extension-leaflet",
-      5000,
+      2000,
     );
     const canvases = await getElementsByCss(
       driver,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1131,6 +1131,11 @@
     "@babel/helper-string-parser" "^7.25.9"
     "@babel/helper-validator-identifier" "^7.25.9"
 
+"@bazel/runfiles@^6.3.1":
+  version "6.3.1"
+  resolved "https://registry.yarnpkg.com/@bazel/runfiles/-/runfiles-6.3.1.tgz#3f8824b2d82853377799d42354b4df78ab0ace0b"
+  integrity sha512-1uLNT5NZsUVIGS4syuHwTzZ8HycMPyr6POA3FCE4GbMtc4rhoJk8aZKtNIRthJYfL+iioppi+rTfH3olMPr9nA==
+
 "@bcoe/v8-coverage@^0.2.3":
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
@@ -3074,20 +3079,21 @@ ecc-jsbn@~0.1.1:
     jsbn "~0.1.0"
     safer-buffer "^2.1.0"
 
-echarts-gl@^2.0.8:
+echarts-gl@^2.0.9:
   version "2.0.9"
   resolved "https://registry.yarnpkg.com/echarts-gl/-/echarts-gl-2.0.9.tgz#ee228a6c7520a6fb7bbb71ea94394f3637ade033"
+  integrity sha512-oKeMdkkkpJGWOzjgZUsF41DOh6cMsyrGGXimbjK2l6Xeq/dBQu4ShG2w2Dzrs/1bD27b2pLTGSaUzouY191gzA==
   dependencies:
     claygl "^1.2.1"
     zrender "^5.1.1"
 
-echarts@^5.3.3:
-  version "5.4.3"
-  resolved "https://registry.yarnpkg.com/echarts/-/echarts-5.4.3.tgz#f5522ef24419164903eedcfd2b506c6fc91fb20c"
-  integrity sha512-mYKxLxhzy6zyTi/FaEbJMOZU1ULGEQHaeIeuMR5L+JnJTpz+YR03mnnpBhbR4+UYJAgiXgpyTVLffPAjOTLkZA==
+echarts@^5.6.0:
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/echarts/-/echarts-5.6.0.tgz#2377874dca9fb50f104051c3553544752da3c9d6"
+  integrity sha512-oTbVTsXfKuEhxftHqL5xprgLoc0k7uScAwtryCgWF6hPYFLRwOUHiFmHGCBKP5NPFNkDVopOieyUqYGH8Fa3kA==
   dependencies:
     tslib "2.3.0"
-    zrender "5.4.4"
+    zrender "5.6.1"
 
 ee-first@1.1.1:
   version "1.1.1"
@@ -4340,6 +4346,11 @@ ignore@^5.2.0, ignore@^5.2.4:
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.3.1.tgz#5073e554cd42c5b33b394375f538b8593e34d4ef"
   integrity sha512-5Fytz/IraMjqpwfd34ke28PTVMjZjJG2MPn5t7OE4eUCUNf8BAa7b5WUS9/Qvr6mwOQS7Mk6vdsMno5he+T8Xw==
 
+immediate@~3.0.5:
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/immediate/-/immediate-3.0.6.tgz#9db1dbd0faf8de6fbe0f5dd5e56bb606280de69b"
+  integrity sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==
+
 import-fresh@^3.2.1:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/import-fresh/-/import-fresh-3.3.0.tgz#37162c25fcb9ebaa2e6e53d5b4d88ce17d9e0c2b"
@@ -4369,7 +4380,7 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2, inherits@2.0.4, inherits@^2.0.1, inherits@^2.0.3, inherits@~2.0.1:
+inherits@2, inherits@2.0.4, inherits@^2.0.1, inherits@^2.0.3, inherits@~2.0.1, inherits@~2.0.3:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
 
@@ -5332,6 +5343,16 @@ jsprim@^1.2.2:
     object.assign "^4.1.4"
     object.values "^1.1.6"
 
+jszip@^3.10.1:
+  version "3.10.1"
+  resolved "https://registry.yarnpkg.com/jszip/-/jszip-3.10.1.tgz#34aee70eb18ea1faec2f589208a157d1feb091c2"
+  integrity sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==
+  dependencies:
+    lie "~3.3.0"
+    pako "~1.0.2"
+    readable-stream "~2.3.6"
+    setimmediate "^1.0.5"
+
 kdbush@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/kdbush/-/kdbush-4.0.2.tgz#2f7b7246328b4657dd122b6c7f025fbc2c868e39"
@@ -5393,6 +5414,13 @@ levn@~0.3.0:
   dependencies:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
+
+lie@~3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/lie/-/lie-3.3.0.tgz#dcf82dee545f46074daf200c7c1c5a08e0f40f6a"
+  integrity sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==
+  dependencies:
+    immediate "~3.0.5"
 
 lilconfig@^3.1.3:
   version "3.1.3"
@@ -5875,6 +5903,11 @@ p-try@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/p-try/-/p-try-2.2.0.tgz#cb2868540e313d61de58fafbe35ce9004d5540e6"
 
+pako@~1.0.2:
+  version "1.0.11"
+  resolved "https://registry.yarnpkg.com/pako/-/pako-1.0.11.tgz#6c9599d340d54dfd3946380252a35705a6b992bf"
+  integrity sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==
+
 param-case@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/param-case/-/param-case-3.0.4.tgz#7d17fe4aa12bde34d4a77d91acfb6219caad01c5"
@@ -6062,6 +6095,11 @@ process-nextick-args@~1.0.6:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-1.0.7.tgz#150e20b756590ad3f91093f25a4f2ad8bff30ba3"
 
+process-nextick-args@~2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.1.tgz#7820d9b16120cc55ca9ae7792680ae7dba6d7fe2"
+  integrity sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==
+
 prompts@^2.0.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/prompts/-/prompts-2.2.1.tgz#f901dd2a2dfee080359c0e20059b24188d75ad35"
@@ -6163,6 +6201,19 @@ readable-stream@^3.0.6:
     inherits "^2.0.3"
     string_decoder "^1.1.1"
     util-deprecate "^1.0.1"
+
+readable-stream@~2.3.6:
+  version "2.3.8"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.8.tgz#91125e8042bba1b9887f49345f6277027ce8be9b"
+  integrity sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==
+  dependencies:
+    core-util-is "~1.0.0"
+    inherits "~2.0.3"
+    isarray "~1.0.0"
+    process-nextick-args "~2.0.0"
+    safe-buffer "~5.1.1"
+    string_decoder "~1.1.1"
+    util-deprecate "~1.0.1"
 
 readdirp@~3.6.0:
   version "3.6.0"
@@ -6444,7 +6495,7 @@ safe-array-concat@^1.1.3:
     has-symbols "^1.1.0"
     isarray "^2.0.5"
 
-safe-buffer@5.1.2:
+safe-buffer@5.1.2, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
 
@@ -6510,6 +6561,16 @@ schema-utils@^4.0.0, schema-utils@^4.2.0, schema-utils@^4.3.0:
 select-hose@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/select-hose/-/select-hose-2.0.0.tgz#625d8658f865af43ec962bfc376a37359a4994ca"
+
+selenium-webdriver@^4.29.0:
+  version "4.29.0"
+  resolved "https://registry.yarnpkg.com/selenium-webdriver/-/selenium-webdriver-4.29.0.tgz#32d32fb60df488bbc399b9dd58728a5cd570210e"
+  integrity sha512-8XPGtDoji5xk7ZUCzFT1rqHmCp67DCzESsttId7DzmrJmlTRmRLF6X918rbwclcH89amcBNM4zB3lVPj404I0g==
+  dependencies:
+    "@bazel/runfiles" "^6.3.1"
+    jszip "^3.10.1"
+    tmp "^0.2.3"
+    ws "^8.18.0"
 
 selfsigned@^2.4.1:
   version "2.4.1"
@@ -6620,6 +6681,11 @@ set-function-name@^2.0.2:
     es-errors "^1.3.0"
     functions-have-names "^1.2.3"
     has-property-descriptors "^1.0.2"
+
+setimmediate@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/setimmediate/-/setimmediate-1.0.5.tgz#290cbb232e306942d7d7ea9b83732ab7856f8285"
+  integrity sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==
 
 setprototypeof@1.1.0:
   version "1.1.0"
@@ -6974,6 +7040,13 @@ string_decoder@~1.0.0:
   dependencies:
     safe-buffer "^5.0.1"
 
+string_decoder@~1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.1.1.tgz#9cf1611ba62685d7030ae9e4ba34149c3af03fc8"
+  integrity sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==
+  dependencies:
+    safe-buffer "~5.1.0"
+
 strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
@@ -7085,6 +7158,11 @@ text-table@^0.2.0:
 thunky@^1.0.2:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/thunky/-/thunky-1.1.0.tgz#5abaf714a9405db0504732bbccd2cedd9ef9537d"
+
+tmp@^0.2.3:
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.2.3.tgz#eb783cc22bc1e8bebd0671476d46ea4eb32a79ae"
+  integrity sha512-nZD7m9iCPC5g0pYmcaxogYKggSfLsdxl8of3Q/oIbqCqLLIO9IAF0GWjX1z9NZRHPiXv8Wex4yDCaZsgEw0Y8w==
 
 tmpl@1.0.5:
   version "1.0.5"
@@ -7765,14 +7843,7 @@ yocto-queue@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-0.1.0.tgz#0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b"
 
-zrender@5.4.4:
-  version "5.4.4"
-  resolved "https://registry.yarnpkg.com/zrender/-/zrender-5.4.4.tgz#8854f1d95ecc82cf8912f5a11f86657cb8c9e261"
-  integrity sha512-0VxCNJ7AGOMCWeHVyTrGzUgrK4asT4ml9PEkeGirAkKNYXYzoPJCLvmyfdoOXcjTHPs10OZVMfD1Rwg16AZyYw==
-  dependencies:
-    tslib "2.3.0"
-
-zrender@^5.1.1, zrender@^5.3.2:
+zrender@5.6.1, zrender@^5.1.1, zrender@^5.6.1:
   version "5.6.1"
   resolved "https://registry.yarnpkg.com/zrender/-/zrender-5.6.1.tgz#e08d57ecf4acac708c4fcb7481eb201df7f10a6b"
   integrity sha512-OFXkDJKcrlx5su2XbzJvj/34Q3m6PvyCZkVPHGYpcCJ52ek4U/ymZyfuV1nKE23AyBJ51E/6Yr0mhZ7xGTO4ag==


### PR DESCRIPTION
Modify import statements according to the updated ECharts module structure.

Fixes #305, #244

## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- [x] I have written new test cases for new code and/or updated existing tests for changes to existing code.

## Reference to Existing Issue

Closes #305 #244.

## Description of Changes

- Updated ECharts to version 5.6.
- Modified import statements to align with the updated ECharts module structure.
- Used `import "echarts-gl"` instead of the file `lib/js/eharts-gl.min.js` which was causing some issues and can be removed if needed.
- One way to do this `import * as echarts from "echarts"` will import the whole library, I have used `import * as echarts from "echarts/core"`; and added other necessary imports accordingly.
- I will add a selenium test for #269 to check the correct renders and console errors during runtime to catch bugs.