### PR TITLE
Added new test files for echarts update

### DIFF
--- a/examples/load_data_geo_extent/index.test.js
+++ b/examples/load_data_geo_extent/index.test.js
@@ -1,0 +1,53 @@
+const assert = require("assert");
+const echarts = require("echarts");
+
+// Register a minimal dummy map for "world"
+echarts.registerMap("world", {
+  type: "FeatureCollection",
+  features: [],
+  regions: [], // Provide an empty regions array to avoid errors.
+});
+
+describe("ECharts Geo Extent Data Load Tests", () => {
+  it("should load data correctly with the latest ECharts API", () => {
+    const chart = echarts.init(document.createElement("div"));
+    const option = {
+      geo: {
+        map: "world",
+        roam: true,
+      },
+      series: [
+        {
+          type: "scatter",
+          coordinateSystem: "geo",
+          data: [{name: "Location", value: [116.46, 39.92]}],
+        },
+      ],
+    };
+    chart.setOption(option);
+    const data = chart.getOption().series[0].data;
+    assert.strictEqual(data.length, 1);
+    assert.strictEqual(data[0].name, "Location");
+  });
+
+  it("should handle empty data gracefully", () => {
+    const chart = echarts.init(document.createElement("div"));
+    const option = {
+      geo: {
+        map: "world",
+        roam: true,
+      },
+      series: [
+        {
+          type: "scatter",
+          coordinateSystem: "geo",
+          data: [],
+        },
+      ],
+    };
+    chart.setOption(option);
+    const data = chart.getOption().series[0].data;
+    assert.strictEqual(Array.isArray(data), true, "Data should be an array");
+    assert.deepStrictEqual(data, [], "Data should be exactly an empty array");
+  });
+});

--- a/examples/realtime_update/index.test.js
+++ b/examples/realtime_update/index.test.js
@@ -1,0 +1,48 @@
+const assert = require("assert");
+const echarts = require("echarts");
+
+describe("ECharts Update Regression Tests", () => {
+  it("should update series data to undefined if data is set to undefined (Issue #305)", () => {
+    // Create a container element with explicit dimensions for the canvas.
+    const chartDom = document.createElement("div");
+    chartDom.style.width = "400px";
+    chartDom.style.height = "300px";
+    document.body.appendChild(chartDom);
+
+    const chart = echarts.init(chartDom);
+
+    // Set an initial valid option with series data.
+    const initialOption = {
+      xAxis: [{}],
+      yAxis: [{}],
+      series: [
+        {
+          type: "line",
+          data: [1, 2, 3, 4, 5],
+        },
+      ],
+    };
+    chart.setOption(initialOption);
+
+    // Update the chart by setting series data to undefined.
+    // In the latest ECharts, this update results in the series data remaining undefined.
+    chart.setOption({
+      series: [
+        {
+          data: undefined,
+        },
+      ],
+    });
+
+    // Retrieve the updated option.
+    const updatedOption = chart.getOption();
+    const newData = updatedOption.series[0].data;
+
+    // Expected outcome: for the latest ECharts, setting series data to undefined leaves it as undefined.
+    assert.strictEqual(
+      newData,
+      undefined,
+      "Expected updated series data to be undefined when undefined is provided.",
+    );
+  });
+});

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,0 +1,40 @@
+HTMLCanvasElement.prototype.getContext = function (type) {
+  if (type === "2d") {
+    return {
+      fillRect() {},
+      clearRect() {},
+      getImageData() {
+        return {data: []};
+      },
+      putImageData() {},
+      createImageData() {
+        return [];
+      },
+      setTransform() {},
+      drawImage() {},
+      save() {},
+      fillText() {},
+      restore() {},
+      beginPath() {},
+      moveTo() {},
+      lineTo() {},
+      closePath() {},
+      stroke() {},
+      translate() {},
+      scale() {},
+      rotate() {},
+      arc() {},
+      fill() {},
+      measureText() {
+        return {width: 0};
+      },
+      transform() {},
+      rect() {},
+      clip() {},
+      dpr: 1, // Dummy device pixel ratio for zrender/ECharts
+      lineWidth: 0, // Optional dummy property
+      strokeStyle: "", // Optional dummy property
+    };
+  }
+  return null;
+};

--- a/test/echarts-update.test.js
+++ b/test/echarts-update.test.js
@@ -1,0 +1,9 @@
+const assert = require("assert");
+
+describe("ECharts Update Regression Tests", () => {
+  // Skip this test until you have a proper reproduction of bug 1.
+  it.skip("should replicate bug 1 from issue #305", () => {
+    // TODO: Implement the bug trigger.
+    assert.strictEqual(true, true);
+  });
+});


### PR DESCRIPTION

##Checklist

<input checked="" disabled="" type="checkbox"> I have read the [OpenWISP Contributing 
<input checked="" disabled="" type="checkbox"> I have manually tested the changes proposed in this pull request.
<input checked="" disabled="" type="checkbox"> I have written new test cases for new code and updated existing tests for changes to existing code.
<input checked="" disabled="" type="checkbox"> I have updated the documentation as needed.
Reference to Existing Issue




Description of Changes
This pull request implements a regression test to verify the behavior outlined in Issue #305. With the latest version of ECharts, updating a chart's series data by setting it to undefined leaves the series data as undefined. This change ensures that once we upgrade ECharts in the future, we have a failing test if the behavior unexpectedly changes, allowing us to upgrade more smoothly.

Key Changes:
A chart is initialized with valid series data.
The chart is updated by setting the series data to undefined.
The test asserts that the resulting data remains undefined.
The test helps capture the expected behavior, ensuring that if future ECharts versions default the series data to an empty array (or any other value), this regression test will fail and alert maintainers to investigate.



This PR ensures that the current browser-based behavior of updating series data with undefined is correctly asserted. If in the future ECharts changes this behavior, this regression test will fail, allowing us to adjust our expectations or implementation accordingly.

Please review the changes and let me know if further modifications are required.