### PR TITLE
[ci] Browser test timeout to 30s

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,8 +84,12 @@ jobs:
           chromedriver --version
           which chromedriver
 
-      - name: Tests
-        run: yarn coverage
+      - name: Unit tests
+        run: yarn coverage --testPathIgnorePatterns=test/netjsongraph.browser.test.js
+  
+      - name: Browser tests
+        # Test timeout set to 30 seconds in CI since it runs slower
+        run: yarn test --runInBand --testTimeout=30000 test/netjsongraph.browser.test.js
 
       - name: Coveralls
         uses: coverallsapp/github-action@master

--- a/test/browser.test.utils.js
+++ b/test/browser.test.utils.js
@@ -19,8 +19,9 @@ const url = "http://0.0.0.0:8080";
 export const getDriver = async () => {
   try {
     const options = new chrome.Options();
-    options.addArguments("--headless");
-    options.addArguments("--remote-debugging-pipe");
+    options.addArguments("--headless=new");
+    options.addArguments("--disable-dev-shm-usage");
+    options.addArguments("--no-sandbox");
     return new Builder().forBrowser("chrome").setChromeOptions(options).build();
   } catch (err) {
     console.error("Failed to initialize driver:", err);


### PR DESCRIPTION
## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- [x] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [ ] I have updated the documentation.

## Reference to Existing Issue

Closes #269.


## Description of Changes

- Separate the step in job `Test and Coverage` for Unit tests and Browser tests in `ci.yml`.
- Set browser test timeout to 30s in only `ci.yml` as it sometimes runs slower and causes test failure.
