### PR TITLE
[tests] Print Console Errors when browser test fails

### DIFF
--- a/test/browser.test.utils.js
+++ b/test/browser.test.utils.js
@@ -121,14 +121,16 @@ export const captureConsoleErrors = async (driver) => {
   );
 };
 
-export const tearDown = async (driver) => {
-  const consoleErrors = await captureConsoleErrors(driver);
-  if (consoleErrors.length > 0) {
-    console.error("Console Errors Detected:");
-    consoleErrors.forEach((error) =>
-      console.error(`${error.level.name}: ${error.message}`),
-    );
+export const printConsoleErrors = (errors) => {
+  if (errors.length > 0) {
+    process.stdout.write("Console Errors Detected:\n");
+    errors.forEach((error) => {
+      process.stdout.write(`${error.level.name}: ${error.message}\n`);
+    });
   }
+};
+
+export const tearDown = async (driver) => {
   await driver.executeScript("window.sessionStorage.clear()");
   await driver.executeScript("window.localStorage.clear()");
   await driver.manage().deleteAllCookies();

--- a/test/netjsongraph.browser.test.js
+++ b/test/netjsongraph.browser.test.js
@@ -7,6 +7,7 @@ import {
   getRenderedNodesAndLinksCount,
   getPresentNodesAndLinksCount,
   urls,
+  printConsoleErrors,
 } from "./browser.test.utils";
 
 describe("Chart Rendering Test", () => {
@@ -20,14 +21,15 @@ describe("Chart Rendering Test", () => {
     await tearDown(driver);
   });
 
-  test("render the Basic usaage example without console errors", async () => {
+  test("render the Basic usage example without console errors", async () => {
     driver.get(urls.basicUsage);
     const canvas = await getElementByCss(driver, "canvas", 2000);
     const consoleErrors = await captureConsoleErrors(driver);
+    printConsoleErrors(consoleErrors);
     const {nodesRendered, linksRendered} =
       await getRenderedNodesAndLinksCount(driver);
     const {nodesPresent, linksPresent} =
-      await getPresentNodesAndLinksCount("Geographic map");
+      await getPresentNodesAndLinksCount("Basic usage");
     expect(consoleErrors.length).toBe(0);
     expect(canvas).not.toBeNull();
     expect(nodesRendered).toBe(nodesPresent);
@@ -50,6 +52,7 @@ describe("Chart Rendering Test", () => {
     const {nodesPresent, linksPresent} =
       await getPresentNodesAndLinksCount("Geographic map");
     const consoleErrors = await captureConsoleErrors(driver);
+    printConsoleErrors(consoleErrors);
     expect(consoleErrors.length).toBe(0);
     expect(leafletContainer).not.toBeNull();
     expect(canvases.length).toBeGreaterThan(0);


### PR DESCRIPTION
## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- [ ] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [ ] I have updated the documentation.

## Reference to Existing Issue 

Closes #352 

## Description of Changes

- Fix getPresentNodesAndLinksCount to fetch from the `Basic usage` example in the test `render the Basic usage example without console errors`
- Print console error if they are found.