### PR TITLE
[fix] Limit default max zoom level on mapOptions #188

### DIFF
--- a/public/example_templates/netjsonmap-indoormap.html
+++ b/public/example_templates/netjsonmap-indoormap.html
@@ -50,7 +50,7 @@
             center: [48.577, 18.539],
             zoom: 5.5,
             zoomSnap: 0.3,
-            minZoom: 3.5,
+            minZoom: 4,
             maxZoom: 9,
             nodeConfig: {
               label: {

--- a/src/css/netjsongraph-theme.css
+++ b/src/css/netjsongraph-theme.css
@@ -7,11 +7,10 @@
   color: #fff !important;
 }
 
-/* Disabled state (when leaflet-disabled is present) */
-.leaflet-control-zoom-in.leaflet-disabled, /* Leaflet adds this */
-.leaflet-control-zoom-out.leaflet-disabled { /* Leaflet adds this */
+.leaflet-control-zoom-in.leaflet-disabled,
+.leaflet-control-zoom-out.leaflet-disabled {
   pointer-events: none;
-  opacity: 0.7; /* Example disabled opacity from PR */
+  opacity: 0.7;
   cursor: default;
 }
 

--- a/src/css/netjsongraph-theme.css
+++ b/src/css/netjsongraph-theme.css
@@ -1,7 +1,18 @@
 .leaflet-control-zoom-in,
 .leaflet-control-zoom-out {
+  pointer-events: auto;
+  opacity: 1;
+  cursor: pointer;
   background: rgba(217, 79, 52, 0.85) !important;
   color: #fff !important;
+}
+
+/* Disabled state (when leaflet-disabled is present) */
+.leaflet-control-zoom-in.leaflet-disabled, /* Leaflet adds this */
+.leaflet-control-zoom-out.leaflet-disabled { /* Leaflet adds this */
+  pointer-events: none;
+  opacity: 0.7; /* Example disabled opacity from PR */
+  cursor: default;
 }
 
 .leaflet-control-layers {

--- a/src/js/netjsongraph.config.js
+++ b/src/js/netjsongraph.config.js
@@ -161,6 +161,8 @@ const NetJSONGraphDefaultConfig = {
   mapOptions: {
     roam: true,
     zoomAnimation: false,
+    minZoom: 3,
+    maxZoom: 18,
     nodeConfig: {
       type: "scatter",
       label: {
@@ -237,8 +239,6 @@ const NetJSONGraphDefaultConfig = {
         process.env.MAPBOX_URL_TEMPLATE ||
         "http://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png",
       options: {
-        minZoom: 3,
-        maxZoom: 32,
         attribution: `&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors,
          tiles offered by <a href="https://www.mapbox.com">Mapbox</a>`,
       },

--- a/test/netjsongraph.browser.test.js
+++ b/test/netjsongraph.browser.test.js
@@ -59,4 +59,37 @@ describe("Chart Rendering Test", () => {
     expect(nodesRendered).toBe(nodesPresent);
     expect(linksRendered).toBe(linksPresent);
   });
+
+  test("should disable zoom-in button at max zoom and show no errors", async () => {
+    driver.get(urls.geographicMap);
+
+    await getElementByCss(driver, ".ec-extension-leaflet", 2000);
+    const zoomInButton = await getElementByCss(driver, ".leaflet-control-zoom-in", 2000);
+    expect(zoomInButton).not.toBeNull();
+
+    for (let i = 0; i < 20; i++) {
+      try {
+        const currentClassName = await zoomInButton.getAttribute("class");
+        if (currentClassName.includes("leaflet-disabled")) {
+          break; // Stop if already disabled
+        }
+        await zoomInButton.click();
+        await driver.sleep(250); // Brief pause for zoom action and UI update
+      } catch (e) {
+        console.log("Error clicking zoom-in button, possibly disabled:", e.message);
+        break;
+      }
+    }
+
+    await driver.wait(async () => {
+      const className = await zoomInButton.getAttribute("class");
+      return className.includes("leaflet-disabled");
+    }, 20000, "Zoom-in button did not become disabled within timeout after repeated clicks");
+
+    await driver.sleep(2000);
+
+    const consoleErrors = await captureConsoleErrors(driver);
+    printConsoleErrors(consoleErrors);
+    expect(consoleErrors.length).toBe(0, "Console errors found after reaching max zoom");
+  });
 });

--- a/test/netjsongraph.spec.js
+++ b/test/netjsongraph.spec.js
@@ -120,6 +120,8 @@ describe("NetJSONGraph Specification", () => {
   const NetJSONGraphMapOptions = {
     roam: true,
     zoomAnimation: false,
+    minZoom: 3,
+    maxZoom: 18,
     nodeConfig: {
       type: "scatter",
       label: {
@@ -251,8 +253,6 @@ describe("NetJSONGraph Specification", () => {
           process.env.MAPBOX_URL_TEMPLATE ||
           "http://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png",
         options: {
-          minZoom: 3,
-          maxZoom: 32,
           attribution: `&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors,
          tiles offered by <a href="https://www.mapbox.com">Mapbox</a>`,
         },


### PR DESCRIPTION
## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- [x] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [x] I have updated the documentation.

## Reference to Existing Issue

Closes #188.

## Description of Changes

- **Zoom Limits:** Set default map `minZoom` to 3 and `maxZoom` to 18 in global configuration.
- **UI Feedback:** Added CSS to style Leaflet's native disabled zoom controls (e.g., `cursor: default`, reduced opacity).
- **Testing:**
  - Updated unit tests to expect new default zoom limits.
  - Added a browser test to verify the zoom-in button becomes disabled at `maxZoom` without errors.

## Screenshot

<img width="1493" alt="image" src="https://github.com/user-attachments/assets/87957d60-8ad5-41b4-a4ea-1bfbad75aa6f" />