### PR TITLE
[fix] Sync label visibility with zoom level in graph

### DIFF
--- a/src/js/netjsongraph.render.js
+++ b/src/js/netjsongraph.render.js
@@ -422,6 +422,11 @@ class NetJSONGraphRender {
             label: {
               show: false,
             },
+            emphasis: {
+              label: {
+                show: false,
+              },
+            },
           },
         ],
       });
@@ -429,11 +434,17 @@ class NetJSONGraphRender {
 
     self.leaflet.on("zoomend", () => {
       const currentZoom = self.leaflet.getZoom();
+      const showLabel = currentZoom >= self.config.showLabelsAtZoomLevel;
       self.echarts.setOption({
         series: [
           {
             label: {
-              show: currentZoom >= self.config.showLabelsAtZoomLevel,
+              show: showLabel,
+            },
+            emphasis: {
+              label: {
+                show: showLabel,
+              },
             },
           },
         ],


### PR DESCRIPTION
Added logic to control label visibility for both normal and emphasis states based on the current zoom level in NetJSONGraphRender. This ensures labels are shown or hidden consistently as users zoom in or out.

## Checklist

- [ ] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [ ] I have manually tested the changes proposed in this pull request.
- [ ] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [ ] I have updated the documentation.

## Reference to Existing Issue

Closes #<issue-number>.

Please [open a new issue](https://github.com/openwisp/netjsongraph.js/issues/new/choose) if there isn't an existing issue yet.

## Description of Changes

Please describe these changes.

## Screenshot

Please include any relevant screenshots.
