### PR TITLE
[fix] Update layout styles for netjsongraph legend example

### DIFF
--- a/public/example_templates/netjsongraph-elementsLegend.html
+++ b/public/example_templates/netjsongraph-elementsLegend.html
@@ -7,6 +7,13 @@
   <link href="../lib/css/netjsongraph-theme.css" rel="stylesheet" />
   <link href="../lib/css/netjsongraph.css" rel="stylesheet" />
   <style>
+    html, body {
+      width: 100%;
+      height: 100%;
+      margin: 0;
+      padding: 0;
+      overflow: hidden;
+    }
     #container {
       width: 100%;
       height: 100%;


### PR DESCRIPTION
Added styles to set html and body to full width and height, removed scroll overflow from #container, and set its position to absolute. This improves the layout and ensures the legend example uses the entire viewport.

## Checklist

- [X] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [X] I have manually tested the changes proposed in this pull request.
- N/A I have written new test cases for new code and/or updated existing tests for changes to existing code.
- N/A I have updated the documentation.

## Reference to Existing Issue

Closes #413 .

## Description of Changes

Added styles to set html and body to full width and height, removed scroll overflow from #container, and set its position to absolute. This improves the layout and ensures the legend example uses the entire viewport.

## Screenshot

<img width="1714" height="1120" alt="image" src="https://github.com/user-attachments/assets/f1876c32-12d1-4585-8df2-a10e5f7239de" />
