### PR TITLE
Fix: redundant node labels and overlays (#454)

### DIFF
--- a/src/js/netjsongraph.config.js
+++ b/src/js/netjsongraph.config.js
@@ -41,7 +41,7 @@ const NetJSONGraphDefaultConfig = {
   clusterRadius: 80,
   clusterSeparation: 20,
   showMetaOnNarrowScreens: false,
-  showLabelsAtZoomLevel: 13,
+  showLabelsAtZoomLevel: 100,
   showGraphLabelsAtZoom: null,
   crs: L.CRS.EPSG3857,
   echartsOption: {


### PR DESCRIPTION
## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).  
- [x] I have manually tested the changes proposed in this pull request.  
- [] I have written new test cases for new code and/or updated existing tests for changes to existing code.  
- [] I have updated the documentation.

## Reference to Existing Issue
Fixes #454

## Description of Changes
This pull request fixes the issue of redundant node labels appearing together with overlay tooltips when zooming into the map.

### Fix Implemented  
Updated the configuration in `NetJSONGraphDefaultConfig`

```diff
- showLabelsAtZoomLevel: 13,
+ showLabelsAtZoomLevel: 100,
```
## After (Fix)
Default Leaflet labels are hidden.
Only overlay tooltips are displayed when hovering or interacting.

## Visual Demonstration
[demo-video.webm](https://github.com/user-attachments/assets/f4506d6f-b32f-4e6e-a060-fe073de16368)