### PR TITLE
Fixed issue 420 Use as much screen estate as possible on initial load

### DIFF
--- a/public/example_templates/netjson-searchElements.html
+++ b/public/example_templates/netjson-searchElements.html
@@ -59,6 +59,8 @@
                   See the following comments for details.
               */
       // `graph` render defaultly.
+      const LABEL_ZOOM_THRESHOLD = 1.2;
+      const SMALL_GRAPH_NODE_COUNT = 40;
       let graph = new NetJSONGraph("../assets/data/netjsonmap.json", {
         onReady: function () {
           let searchContainer = document.createElement("div"),
@@ -103,10 +105,40 @@
 
             searchInput.value = "";
           };
+          applyAutoInitialZoom(this);
         },
       });
 
       graph.render();
+      function applyAutoInitialZoom(instance) {
+          const nodes = instance.data.nodes || [];
+          if (!nodes.length) return;
+
+          const container = instance.el.getBoundingClientRect();
+
+          let minX = Infinity, minY = Infinity;
+          let maxX = -Infinity, maxY = -Infinity;
+
+          nodes.forEach(n => {
+            if (typeof n.x !== "number" || typeof n.y !== "number") return;
+            minX = Math.min(minX, n.x);
+            minY = Math.min(minY, n.y);
+            maxX = Math.max(maxX, n.x);
+            maxY = Math.max(maxY, n.y);
+          });
+
+          const graphArea = (maxX - minX) * (maxY - minY);
+          const viewportArea = container.width * container.height;
+          const densityRatio = graphArea / viewportArea;
+
+          const isSmallGraph =
+            nodes.length <= SMALL_GRAPH_NODE_COUNT ||
+            densityRatio < 0.25;
+
+          if (isSmallGraph) {
+            instance.zoom(LABEL_ZOOM_THRESHOLD + 0.2);
+          }
+        }
     </script>
   </body>
 </html>


### PR DESCRIPTION
Checklist

 I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html)
.I have manually tested the changes proposed in this pull request.
I have written new test cases for new code and/or updated existing tests for changes to existing code.
I have updated the documentation.

Reference to Existing Issue
Closes #420.

Description of Changes
Improves the initial rendering behavior by adapting the initial zoom level to the graph size.

Small graphs are automatically zoomed in so node labels are visible, while large graphs keep the default zoom to use available screen estate and avoid label clutter. This works consistently with the label visibility logic introduced in #419.