### PR TITLE
[fix] Replaced JSON.parse(JSON.stringify()) with structuredClone

### DIFF
--- a/src/js/netjsonWorker.js
+++ b/src/js/netjsonWorker.js
@@ -1,3 +1,15 @@
+/**
+ * Fast deep copy using structuredClone if available, fallback to JSON.parse(JSON.stringify())
+ * @param {any} obj - The object to deep copy
+ * @return {any} - Deep copied object
+ */
+function fastDeepCopy(obj) {
+  if (typeof structuredClone === "function") {
+    return structuredClone(obj);
+  }
+  return JSON.parse(JSON.stringify(obj));
+}
+
 const operations = {
   /**
    * @function
@@ -80,7 +92,7 @@ const operations = {
    *
    */
   changeInterfaceID(JSONData) {
-    const copyLinks = JSON.parse(JSON.stringify(JSONData.links));
+    const copyLinks = fastDeepCopy(JSONData.links);
     for (let i = copyLinks.length - 1; i >= 0; i -= 1) {
       const link = copyLinks[i];
 
@@ -112,7 +124,7 @@ const operations = {
    *
    */
   arrayDeduplication(arrData, eigenvalues = [], ordered = true) {
-    const copyArr = JSON.parse(JSON.stringify(arrData));
+    const copyArr = fastDeepCopy(arrData);
     const tempStack = [];
     for (let i = copyArr.length - 1; i >= 0; i -= 1) {
       const tempValueArr = [];

--- a/src/js/netjsongraph.core.js
+++ b/src/js/netjsongraph.core.js
@@ -86,7 +86,7 @@ class NetJSONGraph {
           // can still be rendered as filled shapes via a separate Leaflet layer later
           // in the rendering pipeline, while the converted NetJSON shape is used for
           // clustering and ECharts overlays.
-          this.originalGeoJSON = JSON.parse(JSON.stringify(JSONData));
+          this.originalGeoJSON = this.utils.fastDeepCopy(JSONData);
           JSONData = this.utils.geojsonToNetjson(JSONData);
         } else {
           throw new Error("Invalid data format!");

--- a/src/js/netjsongraph.render.js
+++ b/src/js/netjsongraph.render.js
@@ -128,7 +128,7 @@ class NetJSONGraphRender {
     const categories = [];
     const configs = self.config;
     const nodes = JSONData.nodes.map((node) => {
-      const nodeResult = JSON.parse(JSON.stringify(node));
+      const nodeResult = self.utils.fastDeepCopy(node);
       const {nodeStyleConfig, nodeSizeConfig, nodeEmphasisConfig} =
         self.utils.getNodeStyle(node, configs, "graph");
 
@@ -149,11 +149,11 @@ class NetJSONGraphRender {
       nodeResult.name = resolvedName;
       // Preserve original NetJSON node for sidebar use
       /* eslint-disable no-underscore-dangle */
-      nodeResult._source = JSON.parse(JSON.stringify(node));
+      nodeResult._source = self.utils.fastDeepCopy(node);
       return nodeResult;
     });
     const links = JSONData.links.map((link) => {
-      const linkResult = JSON.parse(JSON.stringify(link));
+      const linkResult = self.utils.fastDeepCopy(link);
       const {linkStyleConfig, linkEmphasisConfig} = self.utils.getLinkStyle(
         link,
         configs,
@@ -245,7 +245,7 @@ class NetJSONGraphRender {
       if (node.properties) {
         // Maintain flatNodes lookup regardless of whether the node is rendered as a marker
         if (!JSONData.flatNodes) {
-          flatNodes[node.id] = JSON.parse(JSON.stringify(node));
+          flatNodes[node.id] = self.utils.fastDeepCopy(node);
         }
       }
 
@@ -285,7 +285,7 @@ class NetJSONGraphRender {
               symbolSize: nodeEmphasisConfig.nodeSize,
             },
             node,
-            _source: JSON.parse(JSON.stringify(node)),
+            _source: self.utils.fastDeepCopy(node),
           });
         }
       }
@@ -466,7 +466,7 @@ class NetJSONGraphRender {
     // deep-copy it for polygon overlays and convert the working copy to
     // NetJSON so the rest of the pipeline can operate uniformly.
     if (self.utils.isGeoJSON(JSONData)) {
-      self.originalGeoJSON = JSON.parse(JSON.stringify(JSONData));
+      self.originalGeoJSON = self.utils.fastDeepCopy(JSONData);
       JSONData = self.utils.geojsonToNetjson(JSONData);
       // From this point forward we treat the data as NetJSON internally,
       // but keep the public-facing `type` value unchanged ("geojson").

--- a/src/js/netjsongraph.util.js
+++ b/src/js/netjsongraph.util.js
@@ -276,6 +276,18 @@ class NetJSONGraphUtil {
   }
 
   /**
+   * Fast deep copy using structuredClone if available, fallback to JSON.parse(JSON.stringify())
+   * @param {any} obj - The object to deep copy
+   * @return {any} - Deep copied object
+   */
+  fastDeepCopy(obj) {
+    if (typeof structuredClone === "function") {
+      return structuredClone(obj);
+    }
+    return JSON.parse(JSON.stringify(obj));
+  }
+
+  /**
    * merge two object deeply
    *
    * @param  {object}

--- a/test/netjsongraph.render.test.js
+++ b/test/netjsongraph.render.test.js
@@ -980,6 +980,7 @@ describe("Test disableClusteringAtLevel: 0", () => {
           nonClusterNodes: [],
           nonClusterLinks: [],
         })),
+        fastDeepCopy: jest.fn((obj) => JSON.parse(JSON.stringify(obj))),
       },
       event: {
         emit: jest.fn(),
@@ -1076,6 +1077,7 @@ describe("Test leaflet zoomend handler and zoom control state", () => {
         geojsonToNetjson: jest.fn(() => ({nodes: [], links: []})),
         generateMapOption: jest.fn(() => ({series: []})),
         echartsSetOption: jest.fn(),
+        fastDeepCopy: jest.fn((obj) => JSON.parse(JSON.stringify(obj))),
       },
       event: {
         emit: jest.fn(),
@@ -1217,6 +1219,7 @@ describe("mapRender – polygon overlay & moveend bbox logic", () => {
         echartsSetOption: jest.fn(),
         deepMergeObj: jest.fn((a, b) => ({...a, ...b})),
         getBBoxData: jest.fn(() => Promise.resolve({nodes: [{id: "n1"}], links: []})),
+        fastDeepCopy: jest.fn((obj) => JSON.parse(JSON.stringify(obj))),
       },
       event: {emit: jest.fn()},
     };
@@ -1275,6 +1278,7 @@ describe("graph label visibility and fallbacks", () => {
           nodeSizeConfig: 10,
           nodeEmphasisConfig: {nodeStyle: {}, nodeSize: 12},
         })),
+        fastDeepCopy: jest.fn((obj) => JSON.parse(JSON.stringify(obj))),
       },
       echarts: {
         getOption: jest.fn(() => ({series: [{id: "network-graph", zoom: 1}]})),
@@ -1310,6 +1314,7 @@ describe("graph label visibility and fallbacks", () => {
           nodeSizeConfig: 10,
           nodeEmphasisConfig: {nodeStyle: {}, nodeSize: 12},
         })),
+        fastDeepCopy: jest.fn((obj) => JSON.parse(JSON.stringify(obj))),
       },
       echarts: {
         getOption: jest
@@ -1382,6 +1387,7 @@ describe("map series ids and name fallbacks", () => {
           linkStyleConfig: {},
           linkEmphasisConfig: {linkStyle: {}},
         })),
+        fastDeepCopy: jest.fn((obj) => JSON.parse(JSON.stringify(obj))),
       },
     };
 
@@ -1444,6 +1450,7 @@ describe("map series ids and name fallbacks", () => {
         geojsonToNetjson: jest.fn(() => ({nodes: [], links: []})),
         generateMapOption: jest.fn(() => ({series: []})),
         echartsSetOption: jest.fn(),
+        fastDeepCopy: jest.fn((obj) => JSON.parse(JSON.stringify(obj))),
       },
       event: {emit: jest.fn()},
     };


### PR DESCRIPTION
- Add fastDeepCopy utility to NetJSONGraphUtil class using structuredClone with JSON fallback
- Update netjsongraph.render.js (6 instances), netjsongraph.core.js (1 instance), and netjsonWorker.js (2 instances) to use fastDeepCopy
- Update test mocks in netjsongraph.render.test.js to include fastDeepCopy
- Improves performance for large NetJSON datasets by reducing deep copy overhead

## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- [x] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- N/A I have updated the documentation.
