### PR TITLE
[feature] Added configurable popup on node click #402

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,8 +1,9 @@
 module.exports = {
   extends: ["airbnb", "prettier"],
   parserOptions: {
-    ecmaVersion: "latest",
-    sourceType: "module",
+    // Override airbnb-config's ecmaVersion: 2018 so optional chaining
+    // (used by gui.js / util.js) parses without errors.
+    ecmaVersion: 2020,
   },
   rules: {
     "no-param-reassign": "off",

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,5 +1,9 @@
 module.exports = {
   extends: ["airbnb", "prettier"],
+  parserOptions: {
+    ecmaVersion: "latest",
+    sourceType: "module",
+  },
   rules: {
     "no-param-reassign": "off",
     "class-methods-use-this": "off",

--- a/README.md
+++ b/README.md
@@ -463,11 +463,19 @@ NetJSON format used internally is based on [networkgraph](http://netjson.org/rfc
 
   The `linkStyle` property is used to customize the style of the links. The list of all available style properties can be found in the [Echarts documentation](https://echarts.apache.org/en/option.html#series-lines.lineStyle).
 
-  `nodePopup` displays a Leaflet popup when a map node is clicked. Set `show` to `true` to enable it. Set `content` to a function `(node) => DOMElement | string` (invoked with `this` = the netjsongraph instance), or leave it as `null` to use the default node details. Use `config` to pass Leaflet popup options and `onOpen` (invoked with `this` = the netjsongraph instance, no args) to run a callback after the popup opens.
+  `nodePopup` displays a Leaflet popup when a map node is clicked.
+  Set `show` to `true` to enable it. If `content` is `null`, the popup shows the default node details.
+  If you need custom content, set `content` to a function that receives the clicked node and returns a DOM element or a string.
+  Use `config` to pass Leaflet popup options. Use `onOpen` if you need to run code after the popup opens.
 
-  **Note:** `content` can be asynchronous. When multiple async popup requests overlap, only the latest request is rendered; earlier requests' return values are discarded, but **the functions are not cancelled** — any side effects you put inside them (network calls, DOM mutations, analytics) will still run, possibly after a newer click. Don't assume the value you return is what ends up on screen.
+  **Note:** `content` can also return a promise.
+  If the user clicks multiple nodes quickly, only the latest popup result is shown.
+  Older requests may still finish in the background, but their result is ignored.
+  Avoid putting important side effects in `content`, because they may still run after a newer click.
 
-  **Security:** when `content` returns a `string`, Leaflet interprets it as HTML. If the string contains any node data that may come from an untrusted source (remote API, user input, etc.), escape it or — preferably — return a DOM element built with `textContent`, like the built-in `createDefaultPopupContent` does.
+  **Security:** when `content` returns a string, Leaflet treats it as HTML.
+  If the string includes node data from a remote API or user input, escape it first.
+  The safer option is to return a DOM element and set text with `textContent`, like the built-in popup does.
 
 - `mapTileConfig`
 

--- a/README.md
+++ b/README.md
@@ -463,8 +463,11 @@ NetJSON format used internally is based on [networkgraph](http://netjson.org/rfc
 
   The `linkStyle` property is used to customize the style of the links. The list of all available style properties can be found in the [Echarts documentation](https://echarts.apache.org/en/option.html#series-lines.lineStyle).
 
-  `nodePopup` displays a Leaflet popup when a map node is clicked. Set `show` to `true` to enable it. Set `content` to a function that returns a DOM element or string, or leave it as `null` to use the default node details. Use `config` to pass Leaflet popup options and `onOpen` to run a callback after the popup opens.
-  **Note:** `content` can be asynchronous. When multiple async popup requests overlap, only the latest request is used; earlier requests are ignored, but they are not cancelled.
+  `nodePopup` displays a Leaflet popup when a map node is clicked. Set `show` to `true` to enable it. Set `content` to a function `(node) => DOMElement | string` (invoked with `this` = the netjsongraph instance), or leave it as `null` to use the default node details. Use `config` to pass Leaflet popup options and `onOpen` (invoked with `this` = the netjsongraph instance, no args) to run a callback after the popup opens.
+
+  **Note:** `content` can be asynchronous. When multiple async popup requests overlap, only the latest request is rendered; earlier requests' return values are discarded, but **the functions are not cancelled** — any side effects you put inside them (network calls, DOM mutations, analytics) will still run, possibly after a newer click. Don't assume the value you return is what ends up on screen.
+
+  **Security:** when `content` returns a `string`, Leaflet interprets it as HTML. If the string contains any node data that may come from an untrusted source (remote API, user input, etc.), escape it or — preferably — return a DOM element built with `textContent`, like the built-in `createDefaultPopupContent` does.
 
 - `mapTileConfig`
 

--- a/README.md
+++ b/README.md
@@ -433,6 +433,14 @@ NetJSON format used internally is based on [networkgraph](http://netjson.org/rfc
         clusterConfig:{
           // The configuration for the clusters
         },
+        nodePopup:{
+            show: boolean,
+            content: function|HTMLElement|string|null,
+            config:{
+                // Leaflet popup options
+            },
+            onOpen: function,
+        },
         baseOptions:{
             // The global configuration for Echarts specifically for the map.
         }
@@ -454,6 +462,9 @@ NetJSON format used internally is based on [networkgraph](http://netjson.org/rfc
   `linkConfig` deals with the configuration of the links. You can pass any valid [Echarts options](https://echarts.apache.org/en/option.html#series-lines) in `linkConfig`.
 
   The `linkStyle` property is used to customize the style of the links. The list of all available style properties can be found in the [Echarts documentation](https://echarts.apache.org/en/option.html#series-lines.lineStyle).
+
+  `nodePopup` displays a Leaflet popup when a map node is clicked. Set `show` to `true` to enable it, `content` can be a function which returns and HTML element, or `null` to use the default node details. Use `config` for Leaflet popup options and `onOpen` for a async callback after the popup opens.
+  **Note:** For async `content`, only the latest resolved request opens a popup, earlier requests are ignored but not cancelled.
 
 - `mapTileConfig`
 

--- a/README.md
+++ b/README.md
@@ -463,8 +463,8 @@ NetJSON format used internally is based on [networkgraph](http://netjson.org/rfc
 
   The `linkStyle` property is used to customize the style of the links. The list of all available style properties can be found in the [Echarts documentation](https://echarts.apache.org/en/option.html#series-lines.lineStyle).
 
-  `nodePopup` displays a Leaflet popup when a map node is clicked. Set `show` to `true` to enable it, `content` can be a function which returns and HTML element, or `null` to use the default node details. Use `config` for Leaflet popup options and `onOpen` for a async callback after the popup opens.
-  **Note:** For async `content`, only the latest resolved request opens a popup, earlier requests are ignored but not cancelled.
+  `nodePopup` displays a Leaflet popup when a map node is clicked. Set `show` to `true` to enable it. Set `content` to a function that returns a DOM element or string, or leave it as `null` to use the default node details. Use `config` to pass Leaflet popup options and `onOpen` to run a callback after the popup opens.
+  **Note:** `content` can be asynchronous. When multiple async popup requests overlap, only the latest request is used; earlier requests are ignored, but they are not cancelled.
 
 - `mapTileConfig`
 

--- a/public/example_templates/netjsonmap-indoormap-overlay.html
+++ b/public/example_templates/netjsonmap-indoormap-overlay.html
@@ -105,6 +105,8 @@
     </div>
 
     <script>
+      // This example uses popups instead of the default sidebar.
+      const disableDefaultSidebar = () => {};
       const netjsonmap = new NetJSONGraph("../assets/data/netjsonmap.json", {
         el: "#map-content",
         render: "map",
@@ -147,7 +149,7 @@
           });
           return data;
         },
-        onClickElement() {},
+        onClickElement: disableDefaultSidebar,
       });
       netjsonmap.setUtils({
         // Added to open popup for a specific location Id in selenium tests
@@ -408,9 +410,7 @@
               map.setMaxBounds(bnds);
               map.invalidateSize();
             },
-            // Empty onclick needed to override the default coming from config
-            // to the netjsongraph sidebar
-            onClickElement: function () {},
+            onClickElement: disableDefaultSidebar,
           },
         );
         indoor.setUtils({
@@ -454,8 +454,9 @@
             const container = document.getElementById("indoormap-container");
             if (container) {
               container.remove();
-              window._indoorMap = null;
             }
+            window._indoorMap = null;
+            window.removeEventListener("popstate", popstateHandler);
           }
         };
         window.addEventListener("popstate", popstateHandler);

--- a/public/example_templates/netjsonmap-indoormap-overlay.html
+++ b/public/example_templates/netjsonmap-indoormap-overlay.html
@@ -107,6 +107,15 @@
     <script>
       // This example uses popups instead of the default sidebar.
       const disableDefaultSidebar = () => {};
+      // Shared between the outer geo map and the indoor map; the only thing
+      // that differs between the two popups is `content` (custom button for
+      // the geo map, default for the indoor map).
+      const SHARED_POPUP_CONFIG = {
+        closeOnClick: false,
+        autoPan: true,
+        autoPanPadding: [25, 25],
+        offset: [-8, -8],
+      };
       const netjsonmap = new NetJSONGraph("../assets/data/netjsonmap.json", {
         el: "#map-content",
         render: "map",
@@ -124,12 +133,7 @@
           nodePopup: {
             show: true,
             content: createCustomPopup,
-            config: {
-              closeOnClick: false,
-              autoPan: true,
-              autoPanPadding: [25, 25],
-              offset: [-8, -8],
-            },
+            config: SHARED_POPUP_CONFIG,
           },
         },
         bookmarkableActions: {
@@ -224,44 +228,19 @@
         }
       });
 
+      // Called with `this` = the netjsongraph instance (see README docs for
+      // mapOptions.nodePopup.content). We reuse the library's default popup
+      // builder and just append the "Open Floorplan" action.
       function createCustomPopup(node) {
-        const popupContent = document.createElement("div");
-        popupContent.classList.add("default-popup");
-        const location = node?.location || node?.properties?.location;
-        const fields = {
-          name: node?.name,
-          id: node?.id,
-          label: node?.label,
-          location: location
-            ? `${location.lat.toFixed(8)}, ${location.lng.toFixed(8)}`
-            : null,
-        };
-        Object.keys(fields).forEach((key) => {
-          const value = fields[key];
-          if (!value) {
-            return;
-          }
-          const item = document.createElement("div");
-          item.classList.add("njg-tooltip-item");
-          const keyLabel = document.createElement("span");
-          keyLabel.classList.add("njg-tooltip-key");
-          keyLabel.textContent = key;
-          const valueLabel = document.createElement("span");
-          valueLabel.classList.add("njg-tooltip-value");
-          valueLabel.textContent = String(value);
-          item.appendChild(keyLabel);
-          item.appendChild(valueLabel);
-          popupContent.appendChild(item);
-        });
+        const popupContent = this.gui.createDefaultPopupContent(node);
         const buttonContainer = document.createElement("div");
         buttonContainer.classList.add("njg-popup-button-container");
-
         const button = document.createElement("button");
         button.classList.add("njg-popup-button");
         button.textContent = "Open Floorplan";
+        button.addEventListener("click", () => openIndoorMap());
         buttonContainer.appendChild(button);
         popupContent.appendChild(buttonContainer);
-        button.addEventListener("click", () => openIndoorMap());
         return popupContent;
       }
 
@@ -328,12 +307,7 @@
               nodePopup: {
                 show: true,
                 content: null,
-                config: {
-                  closeOnClick: false,
-                  autoPan: true,
-                  autoPanPadding: [25, 25],
-                  offset: [-8, -8],
-                },
+                config: SHARED_POPUP_CONFIG,
               },
             },
             bookmarkableActions: {
@@ -378,15 +352,24 @@
 
               const mapOptions = this.echarts.getOption();
               // Refer netjsonmap-indoormap.html for full explanation of this workaround
-              mapOptions.series[0].data.forEach((data, index) => {
+              // Build an id -> node map so we don't assume the echarts series
+              // data and this.data.nodes share array indices (clustering or
+              // filtering can break that assumption).
+              const nodesById = new Map(this.data.nodes.map((n) => [n.id, n]));
+              mapOptions.series[0].data.forEach((data) => {
                 const node = data.node;
                 const px = Number(node.location.lng);
                 const py = -Number(node.location.lat);
                 const nodeProjected = L.point(topLeft.x + px, topLeft.y + py);
                 const nodeLatLng = map.unproject(nodeProjected, zoom);
-                this.data.nodes[index].location = nodeLatLng;
-                this.data.nodes[index].properties.location = nodeLatLng;
+                const dataNode = nodesById.get(node.id);
+                if (dataNode) {
+                  dataNode.location = nodeLatLng;
+                  dataNode.properties = dataNode.properties || {};
+                  dataNode.properties.location = nodeLatLng;
+                }
                 node.location = nodeLatLng;
+                node.properties = node.properties || {};
                 node.properties.location = nodeLatLng;
                 data.value = [nodeLatLng.lng, nodeLatLng.lat];
               });

--- a/public/example_templates/netjsonmap-indoormap-overlay.html
+++ b/public/example_templates/netjsonmap-indoormap-overlay.html
@@ -206,6 +206,24 @@
         openIndoorMap();
       }
 
+      // Registered once at page load so back/forward navigation keeps working
+      // across repeated open/close cycles. A handler installed inside
+      // openIndoorMap that removes itself on close cannot react to a later
+      // forward-nav that should reopen the indoor map.
+      window.addEventListener("popstate", () => {
+        if (getIndoorMapFragment()) {
+          if (!document.getElementById("indoormap-container")) {
+            openIndoorMap();
+          }
+        } else {
+          const container = document.getElementById("indoormap-container");
+          if (container) {
+            container.remove();
+          }
+          window._indoorMap = null;
+        }
+      });
+
       function createCustomPopup(node) {
         const popupContent = document.createElement("div");
         popupContent.classList.add("default-popup");
@@ -443,28 +461,9 @@
             indoor.echarts.trigger("click", params);
           },
         });
-        const popstateHandler = () => {
-          const fragments = indoor.utils.parseUrlFragments();
-          const id = indoor.config.bookmarkableActions.id;
-          if (fragments[id]) {
-            if (!document.getElementById("indoormap-container")) {
-              openIndoorMap();
-            }
-          } else {
-            const container = document.getElementById("indoormap-container");
-            if (container) {
-              container.remove();
-            }
-            window._indoorMap = null;
-            window.removeEventListener("popstate", popstateHandler);
-          }
-        };
-        window.addEventListener("popstate", popstateHandler);
         indoor.render();
         window._indoorMap = indoor;
-        closeButtonHandler(indoorMapContainer, indoor, () => {
-          window.removeEventListener("popstate", popstateHandler);
-        });
+        closeButtonHandler(indoorMapContainer, indoor);
       }
     </script>
   </body>

--- a/public/example_templates/netjsonmap-indoormap-overlay.html
+++ b/public/example_templates/netjsonmap-indoormap-overlay.html
@@ -73,6 +73,32 @@
       #indoormap-container .njg-container .hidden .sideBarHandle {
         left: 35px;
       }
+      .njg-container .njg-sideBar {
+        display: none;
+      } 
+      .njg-container .leaflet-popup-tip-container {
+        bottom: -5%;
+      }
+      .njg-container .default-popup .njg-popup-button-container{
+        display: flex;
+        justify-content: center;
+      }
+      .njg-container .default-popup .njg-popup-button {
+        padding: 6px 12px;
+        border: none;
+        border-radius: 5px;
+        background-color: black;
+        color: white;
+        cursor: pointer;
+        margin-top: 5px;
+      }
+      .njg-container .default-popup .njg-popup-button:hover{
+        background-color: rgb(85, 85, 85);
+      }
+      .njg-container .leaflet-popup-tip{
+        box-shadow: none;
+      }
+      
     </style>
   </head>
   <body>
@@ -95,6 +121,15 @@
             },
           },
           baseOptions: {media: [{option: {tooltip: {show: true}}}]},
+          nodePopup: {
+            show: true,
+            content:  createCustomPopup,
+            config: {
+              autoPan: true,
+              autoPanPadding: [25, 25],
+              offset: [-8, -8]
+            }
+          },
         },
         bookmarkableActions: {
           enabled: true,
@@ -113,11 +148,7 @@
           });
           return data;
         },
-        onClickElement(type, data) {
-          if (type === "node") {
-            openIndoorMap();
-          }
-        },
+        onClickElement(type, data) {},
       });
       netjsonmap.setUtils({
         // Added to open popup for a specific location Id in selenium tests
@@ -153,6 +184,60 @@
       netjsonmap.render();
       // needed for selenium tests
       window._geoMap = netjsonmap;
+      function getIndoorMapFragment() {
+        const fragments =
+          decodeURIComponent(window.location.hash.replace(/^#/, ""))
+            .split(";")
+            .filter(Boolean);
+
+        return fragments.find((fragment) => {
+          const params = new URLSearchParams(fragment);
+          return params.get("id") === "indoorMap";
+        });
+      }
+      if (getIndoorMapFragment()) {
+        openIndoorMap();
+      }
+
+      function createCustomPopup(node){
+        console.log("Node", node)
+        const popupContent = document.createElement("div");
+        popupContent.classList.add("default-popup");
+        const location = node?.location || node?.properties?.location;
+        const fields = {
+          name: node?.name,
+          id: node?.id,
+          label: node?.label,
+          location: location ? `${location.lat.toFixed(8)}, ${location.lng.toFixed(8)}`: null,
+        };
+        Object.keys(fields).forEach((key) => {
+          const value = fields[key];
+          if (!value) {
+            return;
+          }
+          const item = document.createElement("div");
+          item.classList.add("njg-tooltip-item");
+          const keyLabel = document.createElement("span");
+          keyLabel.classList.add("njg-tooltip-key");
+          keyLabel.innerHTML = key;
+          const valueLabel = document.createElement("span");
+          valueLabel.classList.add("njg-tooltip-value");
+          valueLabel.innerHTML = value;
+          item.appendChild(keyLabel);
+          item.appendChild(valueLabel);
+          popupContent.appendChild(item);
+        });
+        const buttonContainer = document.createElement("div");
+        buttonContainer.classList.add("njg-popup-button-container");
+
+        const button = document.createElement("button");
+        button.classList.add("njg-popup-button");
+        button.innerHTML = "Open Floorplan";
+        buttonContainer.appendChild(button);
+        popupContent.appendChild(buttonContainer);
+        button.addEventListener("click", () => openIndoorMap())
+        return popupContent
+      }
 
       function createIndoorMapContainer() {
         const container = document.createElement("div");
@@ -182,7 +267,6 @@
           container.remove();
         });
       }
-
       function openIndoorMap() {
         let indoorMapContainer = document.getElementById("indoormap-container");
         if (!indoorMapContainer) {
@@ -211,6 +295,15 @@
                 animation: false,
               },
               baseOptions: {media: [{option: {tooltip: {show: true}}}]},
+              nodePopup: {
+                show: true,
+                content:  null,
+                config: {
+                  autoPan: true,
+                  autoPanPadding: [25, 25],
+                  offset: [-8, -8]
+                }
+              },
             },
             bookmarkableActions: {
               enabled: true,
@@ -254,12 +347,14 @@
 
               const mapOptions = this.echarts.getOption();
               // Refer netjsonmap-indoormap.html for full explanation of this workaround
-              mapOptions.series[0].data.forEach((data) => {
+              mapOptions.series[0].data.forEach((data, index) => {
                 const node = data.node;
                 const px = Number(node.location.lng);
                 const py = -Number(node.location.lat);
                 const nodeProjected = L.point(topLeft.x + px, topLeft.y + py);
                 const nodeLatLng = map.unproject(nodeProjected, zoom);
+                this.data.nodes[index].location = nodeLatLng;
+                this.data.nodes[index].properties.location = nodeLatLng;
                 node.location = nodeLatLng;
                 node.properties.location = nodeLatLng;
                 data.value = [nodeLatLng.lng, nodeLatLng.lat];
@@ -302,6 +397,7 @@
               map.setMaxBounds(bnds);
               map.invalidateSize();
             },
+            // onClickElement: function () {},
           },
         );
         indoor.setUtils({

--- a/public/example_templates/netjsonmap-indoormap-overlay.html
+++ b/public/example_templates/netjsonmap-indoormap-overlay.html
@@ -77,11 +77,13 @@
         display: none;
       }
       .njg-container .leaflet-popup-tip-container {
-        bottom: -5%;
+        bottom: -3.5%;
+      }
+      .njg-container .leaflet-popup-tip {
+        box-shadow: none;
       }
       .njg-container .default-popup .njg-popup-button-container {
-        display: flex;
-        justify-content: center;
+        text-align: center;
       }
       .njg-container .default-popup .njg-popup-button {
         padding: 6px 12px;
@@ -94,9 +96,6 @@
       }
       .njg-container .default-popup .njg-popup-button:hover {
         background-color: rgb(85, 85, 85);
-      }
-      .njg-container .leaflet-popup-tip {
-        box-shadow: none;
       }
     </style>
   </head>
@@ -124,6 +123,7 @@
             show: true,
             content: createCustomPopup,
             config: {
+              closeOnClick: false,
               autoPan: true,
               autoPanPadding: [25, 25],
               offset: [-8, -8],
@@ -147,7 +147,7 @@
           });
           return data;
         },
-        onClickElement(type, data) {},
+        onClickElement() {},
       });
       netjsonmap.setUtils({
         // Added to open popup for a specific location Id in selenium tests
@@ -238,7 +238,7 @@
 
         const button = document.createElement("button");
         button.classList.add("njg-popup-button");
-        button.innerHTML = "Open Floorplan";
+        button.textContent = "Open Floorplan";
         buttonContainer.appendChild(button);
         popupContent.appendChild(buttonContainer);
         button.addEventListener("click", () => openIndoorMap());
@@ -309,6 +309,7 @@
                 show: true,
                 content: null,
                 config: {
+                  closeOnClick: false,
                   autoPan: true,
                   autoPanPadding: [25, 25],
                   offset: [-8, -8],
@@ -407,6 +408,8 @@
               map.setMaxBounds(bnds);
               map.invalidateSize();
             },
+            // Empty onclick needed to override the default coming from config
+            // to the netjsongraph sidebar
             onClickElement: function () {},
           },
         );

--- a/public/example_templates/netjsonmap-indoormap-overlay.html
+++ b/public/example_templates/netjsonmap-indoormap-overlay.html
@@ -75,11 +75,11 @@
       }
       .njg-container .njg-sideBar {
         display: none;
-      } 
+      }
       .njg-container .leaflet-popup-tip-container {
         bottom: -5%;
       }
-      .njg-container .default-popup .njg-popup-button-container{
+      .njg-container .default-popup .njg-popup-button-container {
         display: flex;
         justify-content: center;
       }
@@ -92,13 +92,12 @@
         cursor: pointer;
         margin-top: 5px;
       }
-      .njg-container .default-popup .njg-popup-button:hover{
+      .njg-container .default-popup .njg-popup-button:hover {
         background-color: rgb(85, 85, 85);
       }
-      .njg-container .leaflet-popup-tip{
+      .njg-container .leaflet-popup-tip {
         box-shadow: none;
       }
-      
     </style>
   </head>
   <body>
@@ -123,12 +122,12 @@
           baseOptions: {media: [{option: {tooltip: {show: true}}}]},
           nodePopup: {
             show: true,
-            content:  createCustomPopup,
+            content: createCustomPopup,
             config: {
               autoPan: true,
               autoPanPadding: [25, 25],
-              offset: [-8, -8]
-            }
+              offset: [-8, -8],
+            },
           },
         },
         bookmarkableActions: {
@@ -184,11 +183,17 @@
       netjsonmap.render();
       // needed for selenium tests
       window._geoMap = netjsonmap;
+
       function getIndoorMapFragment() {
-        const fragments =
-          decodeURIComponent(window.location.hash.replace(/^#/, ""))
-            .split(";")
-            .filter(Boolean);
+        let decodedHash = "";
+        try {
+          decodedHash = decodeURIComponent(
+            window.location.hash.replace(/^#/, ""),
+          );
+        } catch (err) {
+          return null;
+        }
+        const fragments = decodedHash.split(";").filter(Boolean);
 
         return fragments.find((fragment) => {
           const params = new URLSearchParams(fragment);
@@ -199,8 +204,7 @@
         openIndoorMap();
       }
 
-      function createCustomPopup(node){
-        console.log("Node", node)
+      function createCustomPopup(node) {
         const popupContent = document.createElement("div");
         popupContent.classList.add("default-popup");
         const location = node?.location || node?.properties?.location;
@@ -208,7 +212,9 @@
           name: node?.name,
           id: node?.id,
           label: node?.label,
-          location: location ? `${location.lat.toFixed(8)}, ${location.lng.toFixed(8)}`: null,
+          location: location
+            ? `${location.lat.toFixed(8)}, ${location.lng.toFixed(8)}`
+            : null,
         };
         Object.keys(fields).forEach((key) => {
           const value = fields[key];
@@ -219,10 +225,10 @@
           item.classList.add("njg-tooltip-item");
           const keyLabel = document.createElement("span");
           keyLabel.classList.add("njg-tooltip-key");
-          keyLabel.innerHTML = key;
+          keyLabel.textContent = key;
           const valueLabel = document.createElement("span");
           valueLabel.classList.add("njg-tooltip-value");
-          valueLabel.innerHTML = value;
+          valueLabel.textContent = String(value);
           item.appendChild(keyLabel);
           item.appendChild(valueLabel);
           popupContent.appendChild(item);
@@ -235,8 +241,8 @@
         button.innerHTML = "Open Floorplan";
         buttonContainer.appendChild(button);
         popupContent.appendChild(buttonContainer);
-        button.addEventListener("click", () => openIndoorMap())
-        return popupContent
+        button.addEventListener("click", () => openIndoorMap());
+        return popupContent;
       }
 
       function createIndoorMapContainer() {
@@ -265,9 +271,13 @@
             onClose();
           }
           container.remove();
+          window._indoorMap = null;
         });
       }
       function openIndoorMap() {
+        if (window._indoorMap) {
+          return window._indoorMap;
+        }
         let indoorMapContainer = document.getElementById("indoormap-container");
         if (!indoorMapContainer) {
           indoorMapContainer = createIndoorMapContainer();
@@ -297,12 +307,12 @@
               baseOptions: {media: [{option: {tooltip: {show: true}}}]},
               nodePopup: {
                 show: true,
-                content:  null,
+                content: null,
                 config: {
                   autoPan: true,
                   autoPanPadding: [25, 25],
-                  offset: [-8, -8]
-                }
+                  offset: [-8, -8],
+                },
               },
             },
             bookmarkableActions: {
@@ -397,7 +407,7 @@
               map.setMaxBounds(bnds);
               map.invalidateSize();
             },
-            // onClickElement: function () {},
+            onClickElement: function () {},
           },
         );
         indoor.setUtils({
@@ -433,9 +443,16 @@
         const popstateHandler = () => {
           const fragments = indoor.utils.parseUrlFragments();
           const id = indoor.config.bookmarkableActions.id;
-          if (!fragments[id]) {
-            indoorMapContainer.remove();
-            window.removeEventListener("popstate", popstateHandler);
+          if (fragments[id]) {
+            if (!document.getElementById("indoormap-container")) {
+              openIndoorMap();
+            }
+          } else {
+            const container = document.getElementById("indoormap-container");
+            if (container) {
+              container.remove();
+              window._indoorMap = null;
+            }
           }
         };
         window.addEventListener("popstate", popstateHandler);

--- a/src/css/netjsongraph.css
+++ b/src/css/netjsongraph.css
@@ -397,7 +397,8 @@
 
 .njg-container .default-popup .njg-tooltip-value {
   flex: 1;
-  word-break: break-word;
+  overflow-wrap: anywhere;
+  word-break: normal;
   color: black;
 }
 

--- a/src/css/netjsongraph.css
+++ b/src/css/netjsongraph.css
@@ -365,18 +365,6 @@
 .njg-container .default-popup {
   padding: 18px;
 }
-
-.njg-container .default-popup a.leaflet-popup-close-button {
-  position: absolute;
-  top: 4px;
-  right: 4px;
-  font-size: 18px !important;
-}
-
-.njg-container .default-popup a.leaflet-popup-close-button:hover {
-  color: black !important;
-}
-
 .njg-container .default-popup .njg-tooltip-item {
   display: flex;
   align-items: center;

--- a/src/css/netjsongraph.css
+++ b/src/css/netjsongraph.css
@@ -319,6 +319,10 @@
   user-select: text !important;
 }
 
+.njg-container.njg-hide-tooltip .njg-tooltip {
+  display: none !important;
+}
+
 .njg-container .njg-tooltip .njg-closeButton {
   display: none;
 }

--- a/src/css/netjsongraph.css
+++ b/src/css/netjsongraph.css
@@ -362,6 +362,45 @@
   font-size: 18px;
 }
 
+.njg-container .default-popup {
+  padding: 18px;
+}
+
+.njg-container .default-popup a.leaflet-popup-close-button {
+  position: absolute;
+  top: 4px;
+  right: 4px;
+  font-size: 18px !important;
+}
+
+.njg-container .default-popup a.leaflet-popup-close-button:hover {
+  color: black !important;
+}
+
+.njg-container .default-popup .njg-tooltip-item {
+  display: flex;
+  align-items: center;
+  margin-bottom: 8px;
+  font-size: 14px;
+}
+
+.njg-container .default-popup .njg-tooltip-item:last-child {
+  margin-bottom: 0;
+}
+
+.njg-container .default-popup .njg-tooltip-key {
+  flex-basis: 45%;
+  font-weight: 600;
+  text-transform: capitalize;
+  color: black;
+}
+
+.njg-container .default-popup .njg-tooltip-value {
+  flex: 1;
+  word-break: break-word;
+  color: black;
+}
+
 @media only screen and (max-width: 850px) {
   .njg-container .njg-sideBar {
     top: 0;

--- a/src/js/netjsongraph.config.js
+++ b/src/js/netjsongraph.config.js
@@ -248,10 +248,11 @@ const NetJSONGraphDefaultConfig = {
     nodePopup: {
       show: false,
       content: null,
+      // `offset` is intentionally not set — Leaflet picks an offset that
+      // accounts for its own anchor; we only override autoPan defaults here.
       config: {
         autoPan: true,
         autoPanPadding: [25, 25],
-        offset: null,
       },
     },
   },

--- a/src/js/netjsongraph.config.js
+++ b/src/js/netjsongraph.config.js
@@ -245,6 +245,15 @@ const NetJSONGraphDefaultConfig = {
         },
       ],
     },
+    nodePopup: {
+      show: false,
+      content: null,
+      config: {
+        autoPan: true,
+        autoPanPadding: [25, 25],
+        offset: null,
+      },
+    },
   },
   mapTileConfig: [
     {

--- a/src/js/netjsongraph.gui.js
+++ b/src/js/netjsongraph.gui.js
@@ -299,7 +299,14 @@ class NetJSONGraphGUI {
     const popupRequest = {};
     self.leaflet.currentPopupRequest = popupRequest;
     if (self.leaflet.currentPopup) {
-      self.leaflet.currentPopup.remove();
+      // Null out before remove() so the old popup's "remove" handler bails on
+      // the currentPopup !== popup check. Otherwise it runs the user-close
+      // cleanup path (tooltip/label restore + URL fragment removal), which on
+      // popstate restoration of the same node ends up wiping the URL fragment
+      // we just restored.
+      const previousPopup = self.leaflet.currentPopup;
+      self.leaflet.currentPopup = null;
+      previousPopup.remove();
     }
     let popupContent = self.config.mapOptions.nodePopup.content;
     if (popupContent == null) {

--- a/src/js/netjsongraph.gui.js
+++ b/src/js/netjsongraph.gui.js
@@ -288,23 +288,27 @@ class NetJSONGraphGUI {
       console.error("Leaflet map not available. Cannot load popup.");
       return;
     }
-    if (this.self.echarts) {
-      this.self.echarts.dispatchAction({type: "hideTip"});
-    }
+    this.self.echarts?.setOption({
+      media: [{option: {tooltip: {show: false}}}],
+    });
+    this.self.utils.updateLabelVisibility(this.self, false);
     const nodeLocation = node?.properties?.location || node?.location;
     if (!nodeLocation) {
       console.error("Node location not available. Cannot load popup.");
       return;
     }
+    const bookmarkableActionId =
+      this.self.config.bookmarkableActions && this.self.config.bookmarkableActions.id;
     let popupContent = this.self.config.mapOptions.nodePopup.content;
     if (popupContent == null) {
       popupContent = this.createDefaultPopupContent(node);
-    } else if (popupContent && typeof popupContent === "function") {
+    } else if (typeof popupContent === "function") {
       const popupRequest = popupContent.call(this, node, this.self);
       this.self.leaflet.currentPopupRequest = popupRequest;
       try {
         popupContent = await popupRequest;
       } catch (error) {
+        this.self.utils.removeUrlFragment(bookmarkableActionId, "nodeId");
         if (this.self.leaflet.currentPopupRequest !== popupRequest) {
           return;
         }
@@ -312,6 +316,7 @@ class NetJSONGraphGUI {
         return;
       }
       if (this.self.leaflet.currentPopupRequest !== popupRequest) {
+        this.self.utils.removeUrlFragment(bookmarkableActionId, "nodeId");
         return;
       }
     }
@@ -321,7 +326,6 @@ class NetJSONGraphGUI {
     );
 
     const popup = window.L.popup({
-      closeOnClick: false,
       ...popupConfig,
     })
       .setLatLng(nodeLocation)
@@ -334,24 +338,19 @@ class NetJSONGraphGUI {
       try {
         onOpen.call(this, this.self);
       } catch (error) {
+        this.self.utils.removeUrlFragment(bookmarkableActionId, "nodeId");
         console.error("Failed to run popup onOpen callback:", error);
       }
     }
     const popupElement = popup
       .getElement()
-      .querySelector(".leaflet-popup-close-button");
-    popupElement.addEventListener("click", () => {
-      if (!this.self.config.bookmarkableActions?.enabled) {
-        return;
-      }
-      const fragments = this.self.utils.parseUrlFragments();
-      const {id} = this.self.config.bookmarkableActions;
-      const currentNodeId = fragments[id]?.get("nodeId");
-      const popupNodeId = node?.id || node?.properties?.id;
-      if (currentNodeId === popupNodeId) {
-        fragments[id].delete("nodeId");
-        this.self.utils.updateUrlFragments(fragments);
-      }
+      ?.querySelector(".leaflet-popup-close-button");
+    popupElement?.addEventListener("click", () => {
+      this.self.echarts?.setOption({
+        media: [{option: {tooltip: {show: true}}}],
+      });
+      this.self.utils.updateLabelVisibility(this.self, true);
+      this.self.utils.removeUrlFragment(bookmarkableActionId, "nodeId");
     });
   }
 
@@ -359,13 +358,14 @@ class NetJSONGraphGUI {
     const popupContent = document.createElement("div");
     popupContent.classList.add("default-popup");
     const location = node?.location || node?.properties?.location;
+    const lat = Number(location?.lat);
+    const lng = Number(location?.lng);
+    const hasCoords = Number.isFinite(lat) && Number.isFinite(lng);
     const fields = {
       name: node?.name,
       id: node?.id,
       label: node?.label,
-      location: location
-        ? `${location.lat.toFixed(8)}, ${location.lng.toFixed(8)}`
-        : null,
+      location: hasCoords ? `${lat.toFixed(8)}, ${lng.toFixed(8)}` : null,
     };
     Object.keys(fields).forEach((key) => {
       const value = fields[key];

--- a/src/js/netjsongraph.gui.js
+++ b/src/js/netjsongraph.gui.js
@@ -377,7 +377,7 @@ class NetJSONGraphGUI {
         return;
       }
       // Restore the chart's own tooltip (we hid it while the popup was open).
-      self.echarts?.setOption({tooltip: {show: true}});
+      self.echarts?.setOption({media: [{option: {tooltip: {show: true}}}]});
       self.utils.updateLabelVisibility(self, true);
       if (
         self.config.bookmarkableActions &&
@@ -401,7 +401,7 @@ class NetJSONGraphGUI {
     // Hide the chart's own tooltip so it does not stack with the popup.
     // Direct tooltip option update — earlier code used a one-element media
     // array which clobbered any media queries the consumer had configured.
-    self.echarts?.setOption({tooltip: {show: false}});
+    self.echarts?.setOption({media: [{option: {tooltip: {show: false}}}]});
     self.utils.updateLabelVisibility(self, false);
 
     const {onOpen} = self.config.mapOptions.nodePopup;

--- a/src/js/netjsongraph.gui.js
+++ b/src/js/netjsongraph.gui.js
@@ -288,9 +288,8 @@ class NetJSONGraphGUI {
       console.error("Leaflet map not available. Cannot load popup.");
       return;
     }
-    this.self.echarts?.dispatchAction({type: "hideTip"});
-    if (this.self.leaflet.currentPopup) {
-      this.self.leaflet.currentPopup.remove();
+    if (this.self.echarts) {
+      this.self.echarts.dispatchAction({type: "hideTip"});
     }
     const nodeLocation = node?.properties?.location || node?.location;
     if (!nodeLocation) {
@@ -301,13 +300,27 @@ class NetJSONGraphGUI {
     if (popupContent == null) {
       popupContent = this.createDefaultPopupContent(node);
     } else if (popupContent && typeof popupContent === "function") {
-      popupContent = await popupContent.call(this, node, this.self);
+      const popupRequest = popupContent.call(this, node, this.self);
+      this.self.leaflet.currentPopupRequest = popupRequest;
+      try {
+        popupContent = await popupRequest;
+      } catch (error) {
+        if (this.self.leaflet.currentPopupRequest !== popupRequest) {
+          return;
+        }
+        console.error("Failed to build node popup content:", error);
+        return;
+      }
+      if (this.self.leaflet.currentPopupRequest !== popupRequest) {
+        return;
+      }
     }
-    let popupConfig = this.self.config.mapOptions.nodePopup.config;
-    popupConfig = Object.fromEntries(
-      Object.entries(popupConfig).filter(([, value]) => value != null),
+    const popupConfigInput = this.self.config.mapOptions.nodePopup.config || {};
+    const popupConfig = Object.fromEntries(
+      Object.entries(popupConfigInput).filter(([, value]) => value != null),
     );
-    this.self.leaflet.currentPopup = window.L.popup({
+
+    const popup = window.L.popup({
       closeOnClick: false,
       ...popupConfig,
     })
@@ -315,21 +328,30 @@ class NetJSONGraphGUI {
       .setContent(popupContent)
       .openOn(this.self.leaflet);
 
-    const onOpen = this.self.config.mapOptions.nodePopup.onOpen;
+    this.self.leaflet.currentPopup = popup;
+    const {onOpen} = this.self.config.mapOptions.nodePopup;
     if (onOpen && typeof onOpen === "function") {
-      onOpen.call(this, this.self);
-    }
-
-    this.self.leaflet.currentPopup.on("remove", () => {
-      if (this.self.config.bookmarkableActions?.enabled) {
-        const fragments = this.self.utils.parseUrlFragments();
-        const id = this.self.config.bookmarkableActions.id;
-        if (fragments[id]) {
-          fragments[id].delete("nodeId");
-          this.self.utils.updateUrlFragments(fragments);
-        }
+      try {
+        onOpen.call(this, this.self);
+      } catch (error) {
+        console.error("Failed to run popup onOpen callback:", error);
       }
-      this.self.leaflet.currentPopup = null;
+    }
+    const popupElement = popup
+      .getElement()
+      .querySelector(".leaflet-popup-close-button");
+    popupElement.addEventListener("click", () => {
+      if (!this.self.config.bookmarkableActions?.enabled) {
+        return;
+      }
+      const fragments = this.self.utils.parseUrlFragments();
+      const {id} = this.self.config.bookmarkableActions;
+      const currentNodeId = fragments[id]?.get("nodeId");
+      const popupNodeId = node?.id || node?.properties?.id;
+      if (currentNodeId === popupNodeId) {
+        fragments[id].delete("nodeId");
+        this.self.utils.updateUrlFragments(fragments);
+      }
     });
   }
 
@@ -354,10 +376,10 @@ class NetJSONGraphGUI {
       item.classList.add("njg-tooltip-item");
       const keyLabel = document.createElement("span");
       keyLabel.classList.add("njg-tooltip-key");
-      keyLabel.innerHTML = key;
+      keyLabel.textContent = key;
       const valueLabel = document.createElement("span");
       valueLabel.classList.add("njg-tooltip-value");
-      valueLabel.innerHTML = value;
+      valueLabel.textContent = String(value);
       item.appendChild(keyLabel);
       item.appendChild(valueLabel);
       popupContent.appendChild(item);

--- a/src/js/netjsongraph.gui.js
+++ b/src/js/netjsongraph.gui.js
@@ -329,6 +329,9 @@ class NetJSONGraphGUI {
       self.config.bookmarkableActions && self.config.bookmarkableActions.id;
     const popupRequest = {};
     self.leaflet.currentPopupRequest = popupRequest;
+    // Track whether tooltip/labels were already hidden by an open popup, so
+    // we can restore them if replacement content generation fails.
+    const hadOpenPopup = Boolean(self.leaflet.currentPopup);
     if (self.leaflet.currentPopup) {
       // Null out before remove() so the old popup's "remove" handler bails on
       // the currentPopup !== popup check. Otherwise it runs the user-close
@@ -353,6 +356,13 @@ class NetJSONGraphGUI {
         }
         self.utils.removeUrlFragment(bookmarkableActionId, "nodeId");
         self.leaflet.currentPopupRequest = null;
+        // If we tore down a previous popup before content generation failed,
+        // its remove handler was bypassed — restore tooltip/labels manually so
+        // the map doesn't stay in popup-open visual state with no popup.
+        if (hadOpenPopup) {
+          self.utils.setTooltipVisibility(self, true);
+          self.utils.updateLabelVisibility(self, true);
+        }
         console.error("Failed to build node popup content:", error);
         return;
       }

--- a/src/js/netjsongraph.gui.js
+++ b/src/js/netjsongraph.gui.js
@@ -377,7 +377,7 @@ class NetJSONGraphGUI {
         return;
       }
       // Restore the chart's own tooltip (we hid it while the popup was open).
-      self.echarts?.setOption({media: [{option: {tooltip: {show: true}}}]});
+      self.utils.setTooltipVisibility(self, true);
       self.utils.updateLabelVisibility(self, true);
       if (
         self.config.bookmarkableActions &&
@@ -398,10 +398,8 @@ class NetJSONGraphGUI {
 
     self.leaflet.currentPopup = popup;
     popup.openOn(self.leaflet);
-    // Hide the chart's own tooltip so it does not stack with the popup.
-    // Direct tooltip option update — earlier code used a one-element media
-    // array which clobbered any media queries the consumer had configured.
-    self.echarts?.setOption({media: [{option: {tooltip: {show: false}}}]});
+    // Hide tooltip and labels while the popup is open
+    self.utils.setTooltipVisibility(self, false);
     self.utils.updateLabelVisibility(self, false);
 
     const {onOpen} = self.config.mapOptions.nodePopup;

--- a/src/js/netjsongraph.gui.js
+++ b/src/js/netjsongraph.gui.js
@@ -279,9 +279,40 @@ class NetJSONGraphGUI {
   }
 
   /**
-   * Load and display a popup for a node on the map using leaflet popup
-   * @param {Object} node - The node data containing location and properties
-   * @returns {void}
+   * Canonical lookup order for a node's location. `prepareData` normalizes a
+   * node by setting `properties.location = node.location`, so the
+   * post-pipeline value lives on `properties.location`; we read it first
+   * and fall back to the top-level NetJSON field for nodes that bypass
+   * `prepareData`.
+   *
+   * @param {Object} node
+   * @returns {{lat: number, lng: number}|undefined}
+   */
+  getNodeLocation(node) {
+    return node?.properties?.location || node?.location;
+  }
+
+  /**
+   * Load and display a Leaflet popup for a node on the map.
+   *
+   * Resolves `mapOptions.nodePopup.content`:
+   *   - if `null` → uses the built-in `createDefaultPopupContent`
+   *   - if a function → calls it with `this` = the netjsongraph instance and
+   *     awaits the result (the function may be async)
+   *
+   * Concurrency: only the latest invocation's result is rendered. Earlier
+   * pending content promises are not cancelled; their resolved/rejected
+   * values are discarded. Callers should not assume their content function's
+   * return value reaches the screen.
+   *
+   * Failure handling:
+   *   - if content building throws (sync or async), the URL fragment for the
+   *     current bookmarkable action is cleared and no popup is opened
+   *   - if `onOpen` throws after the popup is shown, the popup is removed
+   *     and the URL fragment is cleared (via the popup's own remove handler)
+   *
+   * @param {Object} node - The node data containing location and properties.
+   * @returns {Promise<void>}
    */
   async loadNodePopup(node) {
     const {self} = this;
@@ -289,7 +320,7 @@ class NetJSONGraphGUI {
       console.error("Leaflet map not available. Cannot load popup.");
       return;
     }
-    const nodeLocation = node?.properties?.location || node?.location;
+    const nodeLocation = this.getNodeLocation(node);
     if (!nodeLocation) {
       console.error("Node location not available. Cannot load popup.");
       return;
@@ -313,7 +344,9 @@ class NetJSONGraphGUI {
       popupContent = this.createDefaultPopupContent(node);
     } else if (typeof popupContent === "function") {
       try {
-        popupContent = await popupContent.call(this, node, self);
+        // Matches the project-wide callback convention: callbacks receive the
+        // netjsongraph instance as `this` and any context as positional args.
+        popupContent = await popupContent.call(self, node);
       } catch (error) {
         if (self.leaflet.currentPopupRequest !== popupRequest) {
           return;
@@ -343,14 +376,17 @@ class NetJSONGraphGUI {
       if (self.leaflet.currentPopup !== popup) {
         return;
       }
-      self.echarts?.setOption({
-        media: [{option: {tooltip: {show: true}}}],
-      });
+      // Restore the chart's own tooltip (we hid it while the popup was open).
+      self.echarts?.setOption({tooltip: {show: true}});
       self.utils.updateLabelVisibility(self, true);
-      if (self.config.bookmarkableActions?.enabled && popupNodeId) {
+      if (
+        self.config.bookmarkableActions &&
+        self.config.bookmarkableActions.enabled &&
+        popupNodeId
+      ) {
         const fragments = self.utils.parseUrlFragments();
         const currentFragment = fragments[bookmarkableActionId];
-        if (currentFragment?.get("nodeId") === popupNodeId) {
+        if (currentFragment && currentFragment.get("nodeId") === popupNodeId) {
           self.utils.removeUrlFragment(bookmarkableActionId, "nodeId");
         }
       }
@@ -362,26 +398,45 @@ class NetJSONGraphGUI {
 
     self.leaflet.currentPopup = popup;
     popup.openOn(self.leaflet);
-    self.echarts?.setOption({
-      media: [{option: {tooltip: {show: false}}}],
-    });
+    // Hide the chart's own tooltip so it does not stack with the popup.
+    // Direct tooltip option update — earlier code used a one-element media
+    // array which clobbered any media queries the consumer had configured.
+    self.echarts?.setOption({tooltip: {show: false}});
     self.utils.updateLabelVisibility(self, false);
 
     const {onOpen} = self.config.mapOptions.nodePopup;
-    if (onOpen && typeof onOpen === "function") {
+    if (typeof onOpen === "function") {
       try {
-        onOpen.call(this, self);
+        onOpen.call(self);
       } catch (error) {
-        self.utils.removeUrlFragment(bookmarkableActionId, "nodeId");
+        // onOpen runs after the popup is already visible. If it throws we
+        // roll back to a consistent state by removing the popup; the popup's
+        // own remove handler clears the URL fragment when it still points
+        // at the now-rolled-back node.
+        if (self.leaflet.currentPopup) {
+          self.leaflet.currentPopup.remove();
+        }
         console.error("Failed to run popup onOpen callback:", error);
       }
     }
   }
 
+  /**
+   * Build the default popup body for a node: a `.default-popup` div with
+   * `name`, `id`, `label`, and `location` rows (rendered only when present).
+   * All values are written with `textContent`, so they are XSS-safe even if
+   * the node fields contain user-controlled strings.
+   *
+   * Consumers may call this from a custom `mapOptions.nodePopup.content`
+   * function and extend the returned element with additional UI.
+   *
+   * @param {Object} node
+   * @returns {HTMLElement}
+   */
   createDefaultPopupContent(node) {
     const popupContent = document.createElement("div");
     popupContent.classList.add("default-popup");
-    const location = node?.location || node?.properties?.location;
+    const location = this.getNodeLocation(node);
     const lat = Number(location?.lat);
     const lng = Number(location?.lng);
     const hasCoords = Number.isFinite(lat) && Number.isFinite(lng);
@@ -393,7 +448,9 @@ class NetJSONGraphGUI {
     };
     Object.keys(fields).forEach((key) => {
       const value = fields[key];
-      if (!value) {
+      // Skip only null/undefined/empty-string; preserve falsy-but-valid
+      // values like id: 0.
+      if (value == null || value === "") {
         return;
       }
       const item = document.createElement("div");

--- a/src/js/netjsongraph.gui.js
+++ b/src/js/netjsongraph.gui.js
@@ -278,6 +278,93 @@ class NetJSONGraphGUI {
     };
   }
 
+  /**
+   * Load and display a popup for a node on the map using leaflet popup
+   * @param {Object} node - The node data containing location and properties
+   * @returns {void}
+   */
+  async loadNodePopup(node) {
+    if (!this.self.leaflet) {
+      console.error("Leaflet map not available. Cannot load popup.");
+      return;
+    }
+    this.self.echarts?.dispatchAction({type: "hideTip"});
+    if (this.self.leaflet.currentPopup) {
+      this.self.leaflet.currentPopup.remove();
+    }
+    const nodeLocation = node?.properties?.location || node?.location;
+    if (!nodeLocation) {
+      console.error("Node location not available. Cannot load popup.");
+      return;
+    }
+    let popupContent = this.self.config.mapOptions.nodePopup.content;
+    if (popupContent == null) {
+      popupContent = this.createDefaultPopupContent(node);
+    } else if (popupContent && typeof popupContent === "function") {
+      popupContent = await popupContent.call(this, node, this.self);
+    }
+    let popupConfig = this.self.config.mapOptions.nodePopup.config;
+    popupConfig = Object.fromEntries(
+      Object.entries(popupConfig).filter(([, value]) => value != null),
+    );
+    this.self.leaflet.currentPopup = window.L.popup({
+      closeOnClick: false,
+      ...popupConfig,
+    })
+      .setLatLng(nodeLocation)
+      .setContent(popupContent)
+      .openOn(this.self.leaflet);
+
+    const onOpen = this.self.config.mapOptions.nodePopup.onOpen;
+    if (onOpen && typeof onOpen === "function") {
+      onOpen.call(this, this.self);
+    }
+
+    this.self.leaflet.currentPopup.on("remove", () => {
+      if (this.self.config.bookmarkableActions?.enabled) {
+        const fragments = this.self.utils.parseUrlFragments();
+        const id = this.self.config.bookmarkableActions.id;
+        if (fragments[id]) {
+          fragments[id].delete("nodeId");
+          this.self.utils.updateUrlFragments(fragments);
+        }
+      }
+      this.self.leaflet.currentPopup = null;
+    });
+  }
+
+  createDefaultPopupContent(node) {
+    const popupContent = document.createElement("div");
+    popupContent.classList.add("default-popup");
+    const location = node?.location || node?.properties?.location;
+    const fields = {
+      name: node?.name,
+      id: node?.id,
+      label: node?.label,
+      location: location
+        ? `${location.lat.toFixed(8)}, ${location.lng.toFixed(8)}`
+        : null,
+    };
+    Object.keys(fields).forEach((key) => {
+      const value = fields[key];
+      if (!value) {
+        return;
+      }
+      const item = document.createElement("div");
+      item.classList.add("njg-tooltip-item");
+      const keyLabel = document.createElement("span");
+      keyLabel.classList.add("njg-tooltip-key");
+      keyLabel.innerHTML = key;
+      const valueLabel = document.createElement("span");
+      valueLabel.classList.add("njg-tooltip-value");
+      valueLabel.innerHTML = value;
+      item.appendChild(keyLabel);
+      item.appendChild(valueLabel);
+      popupContent.appendChild(item);
+    });
+    return popupContent;
+  }
+
   init() {
     this.sideBar = this.createSideBar();
     if (this.self.config.switchMode) {

--- a/src/js/netjsongraph.gui.js
+++ b/src/js/netjsongraph.gui.js
@@ -284,43 +284,43 @@ class NetJSONGraphGUI {
    * @returns {void}
    */
   async loadNodePopup(node) {
-    if (!this.self.leaflet) {
+    const {self} = this;
+    if (!self.leaflet) {
       console.error("Leaflet map not available. Cannot load popup.");
       return;
     }
-    this.self.echarts?.setOption({
-      media: [{option: {tooltip: {show: false}}}],
-    });
-    this.self.utils.updateLabelVisibility(this.self, false);
     const nodeLocation = node?.properties?.location || node?.location;
     if (!nodeLocation) {
       console.error("Node location not available. Cannot load popup.");
       return;
     }
     const bookmarkableActionId =
-      this.self.config.bookmarkableActions && this.self.config.bookmarkableActions.id;
-    let popupContent = this.self.config.mapOptions.nodePopup.content;
+      self.config.bookmarkableActions && self.config.bookmarkableActions.id;
+    const popupRequest = {};
+    self.leaflet.currentPopupRequest = popupRequest;
+    if (self.leaflet.currentPopup) {
+      self.leaflet.currentPopup.remove();
+    }
+    let popupContent = self.config.mapOptions.nodePopup.content;
     if (popupContent == null) {
       popupContent = this.createDefaultPopupContent(node);
     } else if (typeof popupContent === "function") {
-      const popupRequest = popupContent.call(this, node, this.self);
-      this.self.leaflet.currentPopupRequest = popupRequest;
       try {
-        popupContent = await popupRequest;
+        popupContent = await popupContent.call(this, node, self);
       } catch (error) {
-        this.self.utils.removeUrlFragment(bookmarkableActionId, "nodeId");
-        if (this.self.leaflet.currentPopupRequest !== popupRequest) {
+        if (self.leaflet.currentPopupRequest !== popupRequest) {
           return;
         }
+        self.utils.removeUrlFragment(bookmarkableActionId, "nodeId");
+        self.leaflet.currentPopupRequest = null;
         console.error("Failed to build node popup content:", error);
         return;
       }
-      if (this.self.leaflet.currentPopupRequest !== popupRequest) {
-        this.self.utils.removeUrlFragment(bookmarkableActionId, "nodeId");
-        return;
-      }
     }
-    const popupConfigInput = this.self.config.mapOptions.nodePopup.config || {};
+    if (self.leaflet.currentPopupRequest !== popupRequest) {
+      return;
+    }
+    const popupConfigInput = self.config.mapOptions.nodePopup.config || {};
     const popupConfig = Object.fromEntries(
       Object.entries(popupConfigInput).filter(([, value]) => value != null),
     );
@@ -329,29 +329,46 @@ class NetJSONGraphGUI {
       ...popupConfig,
     })
       .setLatLng(nodeLocation)
-      .setContent(popupContent)
-      .openOn(this.self.leaflet);
+      .setContent(popupContent);
+    const popupNodeId = node && node.id != null ? String(node.id) : null;
 
-    this.self.leaflet.currentPopup = popup;
-    const {onOpen} = this.self.config.mapOptions.nodePopup;
+    popup.on("remove", () => {
+      if (self.leaflet.currentPopup !== popup) {
+        return;
+      }
+      self.echarts?.setOption({
+        media: [{option: {tooltip: {show: true}}}],
+      });
+      self.utils.updateLabelVisibility(self, true);
+      if (self.config.bookmarkableActions?.enabled && popupNodeId) {
+        const fragments = self.utils.parseUrlFragments();
+        const currentFragment = fragments[bookmarkableActionId];
+        if (currentFragment?.get("nodeId") === popupNodeId) {
+          self.utils.removeUrlFragment(bookmarkableActionId, "nodeId");
+        }
+      }
+      self.leaflet.currentPopup = null;
+      if (self.leaflet.currentPopupRequest === popupRequest) {
+        self.leaflet.currentPopupRequest = null;
+      }
+    });
+
+    self.leaflet.currentPopup = popup;
+    popup.openOn(self.leaflet);
+    self.echarts?.setOption({
+      media: [{option: {tooltip: {show: false}}}],
+    });
+    self.utils.updateLabelVisibility(self, false);
+
+    const {onOpen} = self.config.mapOptions.nodePopup;
     if (onOpen && typeof onOpen === "function") {
       try {
-        onOpen.call(this, this.self);
+        onOpen.call(this, self);
       } catch (error) {
-        this.self.utils.removeUrlFragment(bookmarkableActionId, "nodeId");
+        self.utils.removeUrlFragment(bookmarkableActionId, "nodeId");
         console.error("Failed to run popup onOpen callback:", error);
       }
     }
-    const popupElement = popup
-      .getElement()
-      ?.querySelector(".leaflet-popup-close-button");
-    popupElement?.addEventListener("click", () => {
-      this.self.echarts?.setOption({
-        media: [{option: {tooltip: {show: true}}}],
-      });
-      this.self.utils.updateLabelVisibility(this.self, true);
-      this.self.utils.removeUrlFragment(bookmarkableActionId, "nodeId");
-    });
   }
 
   createDefaultPopupContent(node) {

--- a/src/js/netjsongraph.render.js
+++ b/src/js/netjsongraph.render.js
@@ -108,9 +108,15 @@ class NetJSONGraphRender {
             params.data,
           );
         }
-        return params.componentSubType === "lines"
-          ? clickElement("link", params.data.link)
-          : !params.data.cluster && clickElement("node", params.data.node);
+        if (params.componentSubType === "lines") {
+          return clickElement("link", params.data.link);
+        }
+        if (!params.data.cluster) {
+          if (configs.mapOptions.nodePopup.show) {
+            self.gui.loadNodePopup(params.data.node);
+          }
+          return clickElement("node", params.data.node);
+        }
       },
       {passive: true},
     );

--- a/src/js/netjsongraph.render.js
+++ b/src/js/netjsongraph.render.js
@@ -110,7 +110,7 @@ class NetJSONGraphRender {
           clickElement("link", params.data.link);
           return;
         }
-        if (!params.data.cluster) {
+        if (params.data && !params.data.cluster) {
           if (configs.mapOptions?.nodePopup?.show) {
             self.gui.loadNodePopup(params.data.node);
           }

--- a/src/js/netjsongraph.render.js
+++ b/src/js/netjsongraph.render.js
@@ -103,21 +103,19 @@ class NetJSONGraphRender {
         const clickElement = configs.onClickElement.bind(self);
         self.utils.addActionToUrl(self, params);
         if (params.componentSubType === "graph") {
-          return clickElement(
-            params.dataType === "edge" ? "link" : "node",
-            params.data,
-          );
+          clickElement(params.dataType === "edge" ? "link" : "node", params.data);
+          return;
         }
         if (params.componentSubType === "lines") {
-          return clickElement("link", params.data.link);
+          clickElement("link", params.data.link);
+          return;
         }
         if (!params.data.cluster) {
-          if (configs.mapOptions.nodePopup.show) {
+          if (configs.mapOptions?.nodePopup?.show) {
             self.gui.loadNodePopup(params.data.node);
           }
-          return clickElement("node", params.data.node);
+          clickElement("node", params.data.node);
         }
-        return null;
       },
       {passive: true},
     );
@@ -605,33 +603,10 @@ class NetJSONGraphRender {
         self.leaflet.fitBounds(bounds, {padding: [20, 20]});
       }
     }
-
-    const updateLabelVisibility = () => {
-      const showLabel =
-        self.config.showMapLabelsAtZoom !== false &&
-        self.leaflet.getZoom() >= self.config.showMapLabelsAtZoom;
-      self.echarts.setOption({
-        series: [
-          {
-            id: "geo-map",
-            label: {
-              show: showLabel,
-              silent: true,
-            },
-            emphasis: {
-              label: {
-                show: false,
-              },
-            },
-          },
-        ],
-      });
-    };
-
-    updateLabelVisibility();
+    self.utils.updateLabelVisibility(self, true);
 
     self.leaflet.on("zoomend", () => {
-      updateLabelVisibility();
+      self.utils.updateLabelVisibility(self, true);
       // Zoom in/out buttons disabled only when it is equal to min/max zoomlevel
       // Manually handle zoom control state to ensure correct behavior with float zoom levels
       const currentZoom = self.leaflet.getZoom();
@@ -729,7 +704,7 @@ class NetJSONGraphRender {
           clusters,
         ),
       );
-      updateLabelVisibility();
+      self.utils.updateLabelVisibility(self, true);
 
       self.echarts.on("click", (params) => {
         if (
@@ -769,7 +744,7 @@ class NetJSONGraphRender {
           // When above the threshold, show all nodes without clustering
           self.echarts.setOption(self.utils.generateMapOption(JSONData, self));
         }
-        updateLabelVisibility();
+        self.utils.updateLabelVisibility(self, true);
       });
     }
 

--- a/src/js/netjsongraph.render.js
+++ b/src/js/netjsongraph.render.js
@@ -117,6 +117,7 @@ class NetJSONGraphRender {
           }
           return clickElement("node", params.data.node);
         }
+        return null;
       },
       {passive: true},
     );

--- a/src/js/netjsongraph.util.js
+++ b/src/js/netjsongraph.util.js
@@ -1381,6 +1381,9 @@ class NetJSONGraphUtil {
         self.leaflet.setView(center, zoom);
       }
     }
+    if (self.config.mapOptions.nodePopup.show) {
+      self.gui.loadNodePopup(node);
+    }
     if (typeof self.config.onClickElement === "function") {
       self.config.onClickElement.call(self, source && target ? "link" : "node", node);
     }

--- a/src/js/netjsongraph.util.js
+++ b/src/js/netjsongraph.util.js
@@ -1496,6 +1496,16 @@ class NetJSONGraphUtil {
       ],
     });
   }
+
+  /**
+   * Hide/show the rendered ECharts tooltip without changing user tooltip config.
+   */
+  setTooltipVisibility(self, visible) {
+    if (!self.el) {
+      return;
+    }
+    self.el.classList.toggle("njg-hide-tooltip", !visible);
+  }
 }
 
 export default NetJSONGraphUtil;

--- a/src/js/netjsongraph.util.js
+++ b/src/js/netjsongraph.util.js
@@ -1328,9 +1328,14 @@ class NetJSONGraphUtil {
     this.updateUrlFragments(fragments, nodeData);
   }
 
-  removeUrlFragment(id) {
+  removeUrlFragment(id, nodeId = null) {
     const fragments = this.parseUrlFragments();
-    if (fragments[id]) {
+    if (!fragments[id]) {
+      return;
+    }
+    if (nodeId) {
+      fragments[id].delete(nodeId);
+    } else {
       delete fragments[id];
     }
     const state = {id};
@@ -1442,6 +1447,33 @@ class NetJSONGraphUtil {
     this.nodeLinkIndex[id].properties.location = location;
     this.echarts.setOption({
       series: options.series,
+    });
+  }
+
+  updateLabelVisibility(self, show) {
+    if (!self.echarts || typeof self.echarts.setOption !== "function") {
+      console.warn("updateLabelVisibility: ECharts instance not ready");
+      return;
+    }
+    const showLabel =
+      show &&
+      self.config.showMapLabelsAtZoom !== false &&
+      self.leaflet.getZoom() >= self.config.showMapLabelsAtZoom;
+    self.echarts.setOption({
+      series: [
+        {
+          id: "geo-map",
+          label: {
+            show: showLabel,
+            silent: true,
+          },
+          emphasis: {
+            label: {
+              show: false,
+            },
+          },
+        },
+      ],
     });
   }
 }

--- a/src/js/netjsongraph.util.js
+++ b/src/js/netjsongraph.util.js
@@ -1381,7 +1381,7 @@ class NetJSONGraphUtil {
         self.leaflet.setView(center, zoom);
       }
     }
-    if (self.config.mapOptions.nodePopup.show) {
+    if (target == null && self.config.mapOptions?.nodePopup?.show) {
       self.gui.loadNodePopup(node);
     }
     if (typeof self.config.onClickElement === "function") {

--- a/src/js/netjsongraph.util.js
+++ b/src/js/netjsongraph.util.js
@@ -1328,13 +1328,28 @@ class NetJSONGraphUtil {
     this.updateUrlFragments(fragments, nodeData);
   }
 
-  removeUrlFragment(id, nodeId = null) {
+  /**
+   * Remove the URL fragment for the given action id, or just one URLSearchParams
+   * key inside that fragment.
+   *
+   * @param {string} id        The bookmarkable action id (e.g. "geoMap").
+   * @param {string} [paramName] If provided, only this query-param is removed
+   *   from the fragment. If omitted, the whole fragment for the id is dropped.
+   */
+  removeUrlFragment(id, paramName = null) {
     const fragments = this.parseUrlFragments();
     if (!fragments[id]) {
       return;
     }
-    if (nodeId) {
-      fragments[id].delete(nodeId);
+    if (paramName) {
+      fragments[id].delete(paramName);
+      // Drop the whole entry if only the bare action id is left — a fragment
+      // like "#id=geoMap" with no other params is a useless stub that
+      // parseUrlFragments would still pick up on subsequent visits.
+      const remainingKeys = Array.from(fragments[id].keys()).filter((k) => k !== "id");
+      if (remainingKeys.length === 0) {
+        delete fragments[id];
+      }
     } else {
       delete fragments[id];
     }
@@ -1352,6 +1367,11 @@ class NetJSONGraphUtil {
     const nodeId =
       fragmentParams && fragmentParams.get ? fragmentParams.get("nodeId") : undefined;
     if (!nodeId || !self.nodeLinkIndex || self.nodeLinkIndex[nodeId] == null) {
+      // Popstate to a state without a selected node: close any open popup so
+      // the visible map state matches the URL.
+      if (self.leaflet && self.leaflet.currentPopup) {
+        self.leaflet.currentPopup.remove();
+      }
       return;
     }
     const [source, target] = nodeId.split("~");

--- a/test/browser.test.utils.js
+++ b/test/browser.test.utils.js
@@ -132,8 +132,13 @@ export const getPresentNodesAndLinksCount = async (example) => {
 
 export const captureConsoleErrors = async (driver) => {
   const logs = await driver.manage().logs().get("browser");
+  // OSM tile 503s are upstream rate-limiting flakes — filter them so CI
+  // does not red on unrelated infrastructure issues.
+  const isIgnoredNoise = (msg) =>
+    msg.includes("favicon.ico") ||
+    (msg.includes("tile.openstreetmap.org") && msg.includes("503"));
   return logs.filter(
-    (log) => log.level.name === "SEVERE" && !log.message.includes("favicon.ico"),
+    (log) => log.level.name === "SEVERE" && !isIgnoredNoise(log.message),
   );
 };
 

--- a/test/browser.test.utils.js
+++ b/test/browser.test.utils.js
@@ -134,9 +134,27 @@ export const captureConsoleErrors = async (driver) => {
   const logs = await driver.manage().logs().get("browser");
   // OSM tile 503s are upstream rate-limiting flakes — filter them so CI
   // does not red on unrelated infrastructure issues.
-  const isIgnoredNoise = (msg) =>
-    msg.includes("favicon.ico") ||
-    (msg.includes("tile.openstreetmap.org") && msg.includes("503"));
+  const isIgnoredNoise = (msg) => {
+    if (msg.includes("favicon.ico")) {
+      return true;
+    }
+    if (!msg.includes("503")) {
+      return false;
+    }
+    const urlMatch = msg.match(/https?:\/\/[^\s"')]+/);
+    if (!urlMatch) {
+      return false;
+    }
+    try {
+      const {hostname} = new URL(urlMatch[0]);
+      return (
+        hostname === "tile.openstreetmap.org" ||
+        hostname.endsWith(".tile.openstreetmap.org")
+      );
+    } catch (error) {
+      return false;
+    }
+  };
   return logs.filter(
     (log) => log.level.name === "SEVERE" && !isIgnoredNoise(log.message),
   );

--- a/test/netjsongraph.browser.test.js
+++ b/test/netjsongraph.browser.test.js
@@ -169,8 +169,7 @@ describe("Chart Rendering Test", () => {
       "//span[@class='njg-valueLabel' and text()='10.149.3.3']",
       2000,
     );
-    const nodeId = await node.getText();
-
+    const nodeId = await node.getAttribute("textContent");
     printConsoleErrors(consoleErrors);
     expect(consoleErrors.length).toBe(0);
     expect(canvas).not.toBeNull();
@@ -195,8 +194,8 @@ describe("Chart Rendering Test", () => {
       "//span[@class='njg-valueLabel' and text()='172.16.155.4']",
       2000,
     );
-    const sourceId = await source.getText();
-    const targetId = await target.getText();
+    const sourceId = await source.getAttribute("textContent");
+    const targetId = await target.getAttribute("textContent");
 
     printConsoleErrors(consoleErrors);
     expect(consoleErrors.length).toBe(0);
@@ -216,7 +215,7 @@ describe("Chart Rendering Test", () => {
       "//span[@class='njg-valueLabel' and text()='172.16.169.1']",
       2000,
     );
-    const nodeId = await node.getText();
+    const nodeId = await node.getAttribute("textContent");
 
     printConsoleErrors(consoleErrors);
     expect(consoleErrors.length).toBe(0);
@@ -242,8 +241,8 @@ describe("Chart Rendering Test", () => {
       "//span[@class='njg-valueLabel' and text()='172.16.185.13']",
       2000,
     );
-    const sourceId = await source.getText();
-    const targetId = await target.getText();
+    const sourceId = await source.getAttribute("textContent");
+    const targetId = await target.getAttribute("textContent");
 
     printConsoleErrors(consoleErrors);
     expect(consoleErrors.length).toBe(0);
@@ -269,6 +268,12 @@ describe("Chart Rendering Test", () => {
     await driver.executeScript('window._geoMap.utils.triggerOnClick("172.16.171.15");');
     let currentUrl = await driver.getCurrentUrl();
     expect(currentUrl).toContain("172.16.171.15");
+    const floorplanBtn = await getElementByCss(driver, ".njg-popup-button", 2000);
+    expect(floorplanBtn).not.toBeNull();
+    // Use JS click to avoid Leaflet popup click interception in Chrome
+    await driver.executeScript("arguments[0].click();", floorplanBtn);
+    // wait for overlay to open and render indoor map
+    await driver.sleep(500);
     let indoorContainer = await getElementByCss(driver, "#indoormap-container", 2000);
     const indoorCanvas = await getElementByCss(driver, "canvas", 2000);
     const floorplanImage = await getElementByCss(driver, ".leaflet-image-layer", 2000);
@@ -297,14 +302,19 @@ describe("Chart Rendering Test", () => {
   test("bookmarkableActions: test url fragments for nodes", async () => {
     await driver.get(`${urls.indoorMapOverlay}#id=geoMap&nodeId=172.16.177.33`);
     const canvas = await getElementByCss(driver, "canvas", 2000);
-    const indoorContainer = await getElementByCss(driver, "#indoormap-container", 2000);
-    const floorplanImage = await getElementByCss(driver, ".leaflet-image-layer", 2000);
+    const indoorContainer = await getElementByCss(driver, ".njg-popup-button", 2000);
+    const node = await getElementByXpath(
+      driver,
+      "//span[@class='njg-tooltip-value' and text()='172.16.177.33']",
+      2000,
+    );
+    const nodeId = await node.getAttribute("textContent");
     const consoleErrors = await captureConsoleErrors(driver);
     printConsoleErrors(consoleErrors);
     expect(consoleErrors.length).toBe(0);
     expect(canvas).not.toBeNull();
     expect(indoorContainer).not.toBeNull();
-    expect(floorplanImage).not.toBeNull();
+    expect(nodeId).toBe("172.16.177.33");
   });
 
   test("bookmarkableActions: test forward/backward actions", async () => {
@@ -314,12 +324,25 @@ describe("Chart Rendering Test", () => {
     await driver.executeScript('window._geoMap.utils.triggerOnClick("172.16.171.15");');
     let currentUrl = await driver.getCurrentUrl();
     expect(currentUrl).toContain("172.16.171.15");
-    let indoorContainer = await getElementByCss(driver, "#indoormap-container");
+    let node = await getElementByXpath(
+      driver,
+      "//span[@class='njg-tooltip-value' and text()='172.16.171.15']",
+      2000,
+    );
+    let nodeId = await node.getAttribute("textContent");
+    expect(nodeId).toBe("172.16.171.15");
+    const floorplanBtn = await getElementByCss(driver, ".njg-popup-button", 2000);
+    expect(floorplanBtn).not.toBeNull();
+    await driver.executeScript("arguments[0].click();", floorplanBtn);
+    // wait for overlay to open and render indoor map
+    await driver.sleep(500);
+    let indoorContainer = await getElementByCss(driver, "#indoormap-container", 2000);
     expect(indoorContainer).not.toBeNull();
     await driver.executeScript('window._indoorMap.utils.triggerOnClick("node_2");');
     currentUrl = await driver.getCurrentUrl();
     expect(currentUrl).toContain("node_2");
     await driver.get("http://0.0.0.0:8080");
+    await driver.sleep(500);
     await driver.navigate().back();
     await driver.sleep(500);
     currentUrl = await driver.getCurrentUrl();
@@ -327,9 +350,13 @@ describe("Chart Rendering Test", () => {
     expect(currentUrl).toContain("node_2");
     indoorContainer = await getElementByCss(driver, "#indoormap-container");
     expect(indoorContainer).not.toBeNull();
-    let node = await getElementByCss(driver, "#indoormap-container .njg-valueLabel");
-    let nodeId = await node.getText();
-    expect(nodeId).toBe("Node_2");
+    node = await getElementByXpath(
+      driver,
+      "//span[@class='njg-tooltip-value' and text()='Node 2']",
+      2000,
+    );
+    nodeId = await node.getAttribute("textContent");
+    expect(nodeId).toBe("Node 2");
     await driver.navigate().back();
     await driver.sleep(500);
     currentUrl = await driver.getCurrentUrl();
@@ -337,6 +364,13 @@ describe("Chart Rendering Test", () => {
     expect(currentUrl).not.toContain("node_2");
     indoorContainer = await getElementByCss(driver, "#indoormap-container");
     expect(indoorContainer).toBeNull();
+    node = await getElementByXpath(
+      driver,
+      "//span[@class='njg-tooltip-value' and text()='172.16.171.15']",
+      2000,
+    );
+    nodeId = await node.getAttribute("textContent");
+    expect(nodeId).toBe("172.16.171.15");
     await driver.navigate().forward();
     await driver.sleep(500);
     currentUrl = await driver.getCurrentUrl();
@@ -344,9 +378,13 @@ describe("Chart Rendering Test", () => {
     expect(currentUrl).toContain("node_2");
     indoorContainer = await getElementByCss(driver, "#indoormap-container");
     expect(indoorContainer).not.toBeNull();
-    node = await getElementByCss(driver, "#indoormap-container .njg-valueLabel");
-    nodeId = await node.getText();
-    expect(nodeId).toBe("Node_2");
+    node = await getElementByXpath(
+      driver,
+      "//span[@class='njg-tooltip-value' and text()='Node 2']",
+      2000,
+    );
+    nodeId = await node.getAttribute("textContent");
+    expect(nodeId).toBe("Node 2");
     const consoleErrors = await captureConsoleErrors(driver);
     printConsoleErrors(consoleErrors);
     expect(consoleErrors.length).toBe(0);
@@ -424,7 +462,7 @@ describe("Chart Rendering Test", () => {
     expect(canvas).not.toBeNull();
 
     // Wait for map to initialize and get initial position
-    await driver.sleep(2000);
+    await driver.sleep(500);
     const initialPosition = await driver.executeScript(() => {
       const options = window.map.echarts.getOption();
       const series = options.series.find((s) => s.type === "scatter");

--- a/test/netjsongraph.browser.test.js
+++ b/test/netjsongraph.browser.test.js
@@ -169,6 +169,11 @@ describe("Chart Rendering Test", () => {
       "//span[@class='njg-valueLabel' and text()='10.149.3.3']",
       2000,
     );
+    // Use textContent rather than getText(): in the popup-based examples the
+    // sidebar is hidden via CSS, and Selenium's getText() returns "" for
+    // elements that aren't visible. textContent gives us the raw text
+    // regardless of layout state, so all the bookmarkable tests stay
+    // consistent across visible-sidebar and hidden-sidebar examples.
     const nodeId = await node.getAttribute("textContent");
     printConsoleErrors(consoleErrors);
     expect(consoleErrors.length).toBe(0);

--- a/test/netjsongraph.browser.test.js
+++ b/test/netjsongraph.browser.test.js
@@ -415,7 +415,7 @@ describe("Chart Rendering Test", () => {
     const consoleErrors = await captureConsoleErrors(driver);
     printConsoleErrors(consoleErrors);
     expect(consoleErrors.length).toBe(0);
-  }, 10000);  // This test needs more time
+  }, 10000); // This test needs more time
 
   test("bookmarkableActions: check if parseUrlFragments handles invalid UTF-8", async () => {
     // Invalid UTF-8 sequence in hash

--- a/test/netjsongraph.browser.test.js
+++ b/test/netjsongraph.browser.test.js
@@ -322,6 +322,28 @@ describe("Chart Rendering Test", () => {
     expect(nodeId).toBe("172.16.177.33");
   });
 
+  test("nodePopup toggles tooltip suppression while popup is open", async () => {
+    await driver.get(urls.indoorMapOverlay);
+    const canvas = await getElementByCss(driver, "canvas", 2000);
+    expect(canvas).not.toBeNull();
+    await driver.executeScript('window._geoMap.utils.triggerOnClick("172.16.171.15");');
+    const popupCloseBtn = await getElementByCss(
+      driver,
+      ".leaflet-popup-close-button",
+      2000,
+    );
+    expect(popupCloseBtn).not.toBeNull();
+    let tooltipSuppressed = await driver.executeScript(
+      'return window._geoMap.el.classList.contains("njg-hide-tooltip");',
+    );
+    expect(tooltipSuppressed).toBe(true);
+    await driver.executeScript("arguments[0].click();", popupCloseBtn);
+    tooltipSuppressed = await driver.executeScript(
+      'return window._geoMap.el.classList.contains("njg-hide-tooltip");',
+    );
+    expect(tooltipSuppressed).toBe(false);
+  });
+
   test("bookmarkableActions: test forward/backward actions", async () => {
     await driver.get(urls.indoorMapOverlay);
     const canvas = await getElementByCss(driver, "canvas", 2000);
@@ -393,7 +415,7 @@ describe("Chart Rendering Test", () => {
     const consoleErrors = await captureConsoleErrors(driver);
     printConsoleErrors(consoleErrors);
     expect(consoleErrors.length).toBe(0);
-  });
+  }, 10000);  // This test needs more time
 
   test("bookmarkableActions: check if parseUrlFragments handles invalid UTF-8", async () => {
     // Invalid UTF-8 sequence in hash

--- a/test/netjsongraph.dom.test.js
+++ b/test/netjsongraph.dom.test.js
@@ -589,7 +589,6 @@ describe("Test GUI loadNodePopup with async and tooltip handling", () => {
   let container;
   let originalLeaflet;
   let mockPopup;
-  let closeButton;
 
   const mockLeafletPopup = (popupElement) => {
     mockPopup = {
@@ -597,6 +596,11 @@ describe("Test GUI loadNodePopup with async and tooltip handling", () => {
       setLatLng: jest.fn(() => mockPopup),
       setContent: jest.fn(() => mockPopup),
       openOn: jest.fn(() => mockPopup),
+      handlers: {},
+      on: jest.fn((event, handler) => {
+        mockPopup.handlers[event] = handler;
+        return mockPopup;
+      }),
     };
     window.L = {
       CRS: {
@@ -609,11 +613,8 @@ describe("Test GUI loadNodePopup with async and tooltip handling", () => {
 
   beforeEach(() => {
     originalLeaflet = window.L;
-    closeButton = {
-      addEventListener: jest.fn(),
-    };
     mockLeafletPopup({
-      querySelector: jest.fn(() => closeButton),
+      querySelector: jest.fn(),
     });
     container = document.createElement("div");
     container.setAttribute("id", "test-popup-map");
@@ -700,16 +701,43 @@ describe("Test GUI loadNodePopup with async and tooltip handling", () => {
     testGraph.utils.updateLabelVisibility = jest.fn();
     testGraph.utils.removeUrlFragment = jest.fn();
     const node = {id: "node-1", location: {lat: 10, lng: 20}};
-    try {
-      await testGraph.gui.loadNodePopup(node);
-    } catch (e) {
-      // Expected to fail
-    }
-    // Should remove URL fragment on error
+    await testGraph.gui.loadNodePopup(node);
     expect(testGraph.utils.removeUrlFragment).toHaveBeenCalledWith("id", "nodeId");
+    expect(testGraph.echarts.setOption).not.toHaveBeenCalled();
+    expect(testGraph.utils.updateLabelVisibility).not.toHaveBeenCalled();
   });
 
-  test("loadNodePopup sets up popup close handler to restore tooltip", async () => {
+  test("loadNodePopup catches synchronous custom content errors", async () => {
+    const contentHandler = jest.fn(() => {
+      throw new Error("Content build failed");
+    });
+    testGraph.setConfig({
+      mapOptions: {
+        nodePopup: {
+          show: true,
+          content: contentHandler,
+          config: {autoPan: true},
+        },
+      },
+    });
+    testGraph.echarts = {
+      setOption: jest.fn(),
+    };
+    testGraph.leaflet = {
+      currentPopup: null,
+      currentPopupRequest: null,
+      once: jest.fn(),
+      off: jest.fn(),
+    };
+    testGraph.utils.updateLabelVisibility = jest.fn();
+    testGraph.utils.removeUrlFragment = jest.fn();
+    const node = {id: "node-1", location: {lat: 10, lng: 20}};
+    await testGraph.gui.loadNodePopup(node);
+    expect(testGraph.utils.removeUrlFragment).toHaveBeenCalledWith("id", "nodeId");
+    expect(testGraph.echarts.setOption).not.toHaveBeenCalled();
+  });
+
+  test("loadNodePopup restores tooltip and removes matching fragment on popup remove", async () => {
     testGraph.echarts = {
       setOption: jest.fn(),
     };
@@ -719,17 +747,94 @@ describe("Test GUI loadNodePopup with async and tooltip handling", () => {
       off: jest.fn(),
     };
     testGraph.utils.updateLabelVisibility = jest.fn();
+    testGraph.utils.parseUrlFragments = jest.fn(() => ({
+      id: new URLSearchParams("id=id&nodeId=node-1"),
+    }));
+    testGraph.utils.removeUrlFragment = jest.fn();
     const node = {id: "node-1", location: {lat: 10, lng: 20}};
     await testGraph.gui.loadNodePopup(node);
-    expect(closeButton.addEventListener).toHaveBeenCalledWith(
-      "click",
-      expect.any(Function),
-    );
-    closeButton.addEventListener.mock.calls[0][1]();
+    expect(mockPopup.on).toHaveBeenCalledWith("remove", expect.any(Function));
+    mockPopup.handlers.remove();
     expect(testGraph.echarts.setOption).toHaveBeenCalledWith({
       media: [{option: {tooltip: {show: true}}}],
     });
     expect(testGraph.utils.updateLabelVisibility).toHaveBeenCalledWith(testGraph, true);
+    expect(testGraph.utils.removeUrlFragment).toHaveBeenCalledWith("id", "nodeId");
+  });
+
+  test("loadNodePopup ignores stale async content without clearing newer URL fragment", async () => {
+    let resolveFirst;
+    const asyncContentHandler = jest
+      .fn()
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveFirst = resolve;
+          }),
+      )
+      .mockResolvedValueOnce("<div>Second Popup</div>");
+    testGraph.setConfig({
+      mapOptions: {
+        nodePopup: {
+          show: true,
+          content: asyncContentHandler,
+          config: {autoPan: true},
+        },
+      },
+    });
+    testGraph.echarts = {
+      setOption: jest.fn(),
+    };
+    testGraph.leaflet = {
+      currentPopup: null,
+      currentPopupRequest: null,
+      once: jest.fn(),
+      off: jest.fn(),
+    };
+    testGraph.utils.updateLabelVisibility = jest.fn();
+    testGraph.utils.removeUrlFragment = jest.fn();
+    const node = {id: "node-1", location: {lat: 10, lng: 20}};
+    const firstRequest = testGraph.gui.loadNodePopup(node);
+    await testGraph.gui.loadNodePopup(node);
+    resolveFirst("<div>First Popup</div>");
+    await firstRequest;
+    expect(testGraph.utils.removeUrlFragment).not.toHaveBeenCalled();
+    expect(mockPopup.setContent).toHaveBeenCalledWith("<div>Second Popup</div>");
+  });
+
+  test("loadNodePopup closes the current popup before waiting for async content", async () => {
+    let resolveContent;
+    const asyncContentHandler = jest.fn(
+      () =>
+        new Promise((resolve) => {
+          resolveContent = resolve;
+        }),
+    );
+    testGraph.setConfig({
+      mapOptions: {
+        nodePopup: {
+          show: true,
+          content: asyncContentHandler,
+          config: {autoPan: true},
+        },
+      },
+    });
+    const currentPopup = {remove: jest.fn()};
+    testGraph.echarts = {
+      setOption: jest.fn(),
+    };
+    testGraph.leaflet = {
+      currentPopup,
+      currentPopupRequest: null,
+      once: jest.fn(),
+      off: jest.fn(),
+    };
+    testGraph.utils.updateLabelVisibility = jest.fn();
+    const node = {id: "node-1", location: {lat: 10, lng: 20}};
+    const popupRequest = testGraph.gui.loadNodePopup(node);
+    expect(currentPopup.remove).toHaveBeenCalled();
+    resolveContent("<div>New Popup</div>");
+    await popupRequest;
   });
 
   test("loadNodePopup handles null popup element gracefully", async () => {

--- a/test/netjsongraph.dom.test.js
+++ b/test/netjsongraph.dom.test.js
@@ -678,6 +678,7 @@ describe("Test GUI loadNodePopup with async and tooltip handling", () => {
   });
 
   afterEach(() => {
+    jest.restoreAllMocks();
     if (container && document.body.contains(container)) {
       document.body.removeChild(container);
     }
@@ -993,7 +994,10 @@ describe("Test GUI loadNodePopup with async and tooltip handling", () => {
     await testGraph.gui.loadNodePopup(node);
     expect(mockPopup.remove).toHaveBeenCalled();
     expect(testGraph.utils.removeUrlFragment).toHaveBeenCalledWith("id", "nodeId");
-    consoleErrorSpy.mockRestore();
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      "Failed to run popup onOpen callback:",
+      onOpenError,
+    );
   });
 
   test("loadNodePopup preserves URL fragment when replacing popup for the still-current node", async () => {

--- a/test/netjsongraph.dom.test.js
+++ b/test/netjsongraph.dom.test.js
@@ -699,7 +699,7 @@ describe("Test GUI loadNodePopup with async and tooltip handling", () => {
     const node = {id: "node-1", location: {lat: 10, lng: 20}};
     await testGraph.gui.loadNodePopup(node);
     expect(testGraph.echarts.setOption).toHaveBeenCalledWith({
-      tooltip: {show: false},
+      media: [{option: {tooltip: {show: false}}}],
     });
     expect(testGraph.utils.updateLabelVisibility).toHaveBeenCalledWith(
       testGraph,
@@ -791,7 +791,7 @@ describe("Test GUI loadNodePopup with async and tooltip handling", () => {
     expect(mockPopup.on).toHaveBeenCalledWith("remove", expect.any(Function));
     mockPopup.handlers.remove();
     expect(testGraph.echarts.setOption).toHaveBeenCalledWith({
-      tooltip: {show: true},
+      media: [{option: {tooltip: {show: true}}}],
     });
     expect(testGraph.utils.updateLabelVisibility).toHaveBeenCalledWith(testGraph, true);
     expect(testGraph.utils.removeUrlFragment).toHaveBeenCalledWith("id", "nodeId");
@@ -990,11 +990,12 @@ describe("Test GUI loadNodePopup with async and tooltip handling", () => {
         mockPopup.handlers.remove();
       }
     });
-    global.console.error = jest.fn();
+    const consoleErrorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
     const node = {id: "node-1", location: {lat: 10, lng: 20}};
     await testGraph.gui.loadNodePopup(node);
     expect(mockPopup.remove).toHaveBeenCalled();
     expect(testGraph.utils.removeUrlFragment).toHaveBeenCalledWith("id", "nodeId");
+    consoleErrorSpy.mockRestore();
   });
 
   test("loadNodePopup preserves URL fragment when replacing popup for the still-current node", async () => {

--- a/test/netjsongraph.dom.test.js
+++ b/test/netjsongraph.dom.test.js
@@ -944,4 +944,59 @@ describe("Test GUI loadNodePopup with async and tooltip handling", () => {
     // Verify URL fragment was cleaned up on error
     expect(testGraph.utils.removeUrlFragment).toHaveBeenCalledWith("id", "nodeId");
   });
+
+  test("loadNodePopup preserves URL fragment when replacing popup for the still-current node", async () => {
+    // Reproduces the popstate-restoration regression: when the URL still
+    // points to the currently-open node and applyUrlFragmentState re-invokes
+    // loadNodePopup for that same node, removing the previous popup must
+    // not trigger the user-close cleanup that strips the URL fragment.
+    const popups = [];
+    const makePopup = () => {
+      const popup = {
+        setLatLng: jest.fn(() => popup),
+        setContent: jest.fn(() => popup),
+        openOn: jest.fn(() => popup),
+        handlers: {},
+        on: jest.fn((event, handler) => {
+          popup.handlers[event] = handler;
+          return popup;
+        }),
+        remove: jest.fn(() => {
+          // Match real Leaflet: firing remove() invokes the "remove" event
+          // listener synchronously.
+          if (typeof popup.handlers.remove === "function") {
+            popup.handlers.remove();
+          }
+        }),
+      };
+      popups.push(popup);
+      return popup;
+    };
+    window.L = {CRS: {EPSG3857: {}}, popup: jest.fn(makePopup)};
+    global.L = window.L;
+
+    testGraph.echarts = {setOption: jest.fn()};
+    testGraph.leaflet = {
+      currentPopup: null,
+      currentPopupRequest: null,
+      once: jest.fn(),
+      off: jest.fn(),
+    };
+    testGraph.utils.updateLabelVisibility = jest.fn();
+    testGraph.utils.parseUrlFragments = jest.fn(() => ({
+      id: new URLSearchParams("id=id&nodeId=node-1"),
+    }));
+    testGraph.utils.removeUrlFragment = jest.fn();
+
+    const node = {id: "node-1", location: {lat: 10, lng: 20}};
+    await testGraph.gui.loadNodePopup(node);
+    expect(popups).toHaveLength(1);
+
+    // Second invocation for the same node (popstate restoration path).
+    await testGraph.gui.loadNodePopup(node);
+    expect(popups).toHaveLength(2);
+    expect(popups[0].remove).toHaveBeenCalled();
+
+    expect(testGraph.utils.removeUrlFragment).not.toHaveBeenCalled();
+  });
 });

--- a/test/netjsongraph.dom.test.js
+++ b/test/netjsongraph.dom.test.js
@@ -582,6 +582,40 @@ describe("Test GUI createDefaultPopupContent", () => {
     expect(content).toBeInstanceOf(HTMLElement);
     expect(content.classList.contains("default-popup")).toBe(true);
   });
+
+  test("Create default popup content prefers properties.location over top-level location", () => {
+    // loadNodePopup positions the popup using node.properties.location ||
+    // node.location. createDefaultPopupContent must read coordinates in the
+    // same order, otherwise the rendered text would disagree with the popup
+    // position when both fields exist with different values.
+    const node = {
+      id: "node-mismatch",
+      location: {lat: 1, lng: 2},
+      properties: {location: {lat: 3, lng: 4}},
+    };
+    const content = graph.gui.createDefaultPopupContent(node);
+    expect(content.innerHTML).toContain("3.00000000");
+    expect(content.innerHTML).toContain("4.00000000");
+    expect(content.innerHTML).not.toContain("1.00000000");
+    expect(content.innerHTML).not.toContain("2.00000000");
+  });
+
+  test("Create default popup content keeps falsy-but-valid id (id:0)", () => {
+    // id:0 is a legal integer NetJSON node id and must not be filtered out.
+    const node = {
+      id: 0,
+      name: "Origin node",
+      label: "Origin",
+    };
+    const content = graph.gui.createDefaultPopupContent(node);
+    expect(content).toBeInstanceOf(HTMLElement);
+    const items = content.querySelectorAll(".njg-tooltip-item");
+    const idItem = Array.from(items).find(
+      (el) => el.querySelector(".njg-tooltip-key")?.textContent === "id",
+    );
+    expect(idItem).toBeDefined();
+    expect(idItem.querySelector(".njg-tooltip-value").textContent).toBe("0");
+  });
 });
 
 describe("Test GUI loadNodePopup with async and tooltip handling", () => {
@@ -601,6 +635,7 @@ describe("Test GUI loadNodePopup with async and tooltip handling", () => {
         mockPopup.handlers[event] = handler;
         return mockPopup;
       }),
+      remove: jest.fn(),
     };
     window.L = {
       CRS: {
@@ -664,7 +699,7 @@ describe("Test GUI loadNodePopup with async and tooltip handling", () => {
     const node = {id: "node-1", location: {lat: 10, lng: 20}};
     await testGraph.gui.loadNodePopup(node);
     expect(testGraph.echarts.setOption).toHaveBeenCalledWith({
-      media: [{option: {tooltip: {show: false}}}],
+      tooltip: {show: false},
     });
     expect(testGraph.utils.updateLabelVisibility).toHaveBeenCalledWith(
       testGraph,
@@ -756,7 +791,7 @@ describe("Test GUI loadNodePopup with async and tooltip handling", () => {
     expect(mockPopup.on).toHaveBeenCalledWith("remove", expect.any(Function));
     mockPopup.handlers.remove();
     expect(testGraph.echarts.setOption).toHaveBeenCalledWith({
-      media: [{option: {tooltip: {show: true}}}],
+      tooltip: {show: true},
     });
     expect(testGraph.utils.updateLabelVisibility).toHaveBeenCalledWith(testGraph, true);
     expect(testGraph.utils.removeUrlFragment).toHaveBeenCalledWith("id", "nodeId");
@@ -876,8 +911,11 @@ describe("Test GUI loadNodePopup with async and tooltip handling", () => {
     testGraph.utils.updateLabelVisibility = jest.fn();
     const node = {id: "node-1", location: {lat: 10, lng: 20}};
     await testGraph.gui.loadNodePopup(node);
-    // Verify async content was resolved and popup was created with it
-    expect(asyncContentHandler).toHaveBeenCalledWith(node, testGraph);
+    // Verify async content was resolved and popup was created with it.
+    // Callback receives the netjsongraph instance as `this` (project-wide
+    // callback convention) and the node as the positional argument.
+    expect(asyncContentHandler).toHaveBeenCalledWith(node);
+    expect(asyncContentHandler.mock.instances[0]).toBe(testGraph);
     expect(mockPopup.setContent).toHaveBeenCalledWith(customContent);
   });
 
@@ -905,11 +943,16 @@ describe("Test GUI loadNodePopup with async and tooltip handling", () => {
     testGraph.utils.removeUrlFragment = jest.fn();
     const node = {id: "node-1", location: {lat: 10, lng: 20}};
     await testGraph.gui.loadNodePopup(node);
-    // Verify onOpen callback was called
-    expect(onOpenCallback).toHaveBeenCalledWith(testGraph);
+    // Verify onOpen callback was called with the netjsongraph instance as
+    // `this` (project-wide callback convention) and no positional args.
+    expect(onOpenCallback).toHaveBeenCalledWith();
+    expect(onOpenCallback.mock.instances[0]).toBe(testGraph);
   });
 
-  test("loadNodePopup handles onOpen callback error and cleans up URL fragment", async () => {
+  test("loadNodePopup closes the popup and clears URL when onOpen throws", async () => {
+    // The popup is already visible by the time onOpen runs (openOn happens
+    // before onOpen is invoked). If onOpen throws, both the URL fragment and
+    // the popup must be rolled back so the visible map state matches the URL.
     const onOpenError = new Error("onOpen failed");
     const onOpenCallback = jest.fn(() => {
       throw onOpenError;
@@ -928,20 +971,29 @@ describe("Test GUI loadNodePopup with async and tooltip handling", () => {
         id: "id",
       },
     });
-    testGraph.echarts = {
-      setOption: jest.fn(),
-    };
+    testGraph.echarts = {setOption: jest.fn()};
     testGraph.leaflet = {
       currentPopup: null,
       once: jest.fn(),
       off: jest.fn(),
     };
     testGraph.utils.updateLabelVisibility = jest.fn();
+    testGraph.utils.parseUrlFragments = jest.fn(() => ({
+      id: new URLSearchParams("id=id&nodeId=node-1"),
+    }));
     testGraph.utils.removeUrlFragment = jest.fn();
+    // Match real Leaflet: .remove() fires the registered "remove" handler
+    // synchronously. This lets the assertions confirm both that the popup
+    // got removed AND that the handler then cleared the URL fragment.
+    mockPopup.remove = jest.fn(() => {
+      if (typeof mockPopup.handlers.remove === "function") {
+        mockPopup.handlers.remove();
+      }
+    });
     global.console.error = jest.fn();
     const node = {id: "node-1", location: {lat: 10, lng: 20}};
     await testGraph.gui.loadNodePopup(node);
-    // Verify URL fragment was cleaned up on error
+    expect(mockPopup.remove).toHaveBeenCalled();
     expect(testGraph.utils.removeUrlFragment).toHaveBeenCalledWith("id", "nodeId");
   });
 

--- a/test/netjsongraph.dom.test.js
+++ b/test/netjsongraph.dom.test.js
@@ -696,11 +696,10 @@ describe("Test GUI loadNodePopup with async and tooltip handling", () => {
       off: jest.fn(),
     };
     testGraph.utils.updateLabelVisibility = jest.fn();
+    testGraph.utils.setTooltipVisibility = jest.fn();
     const node = {id: "node-1", location: {lat: 10, lng: 20}};
     await testGraph.gui.loadNodePopup(node);
-    expect(testGraph.echarts.setOption).toHaveBeenCalledWith({
-      media: [{option: {tooltip: {show: false}}}],
-    });
+    expect(testGraph.utils.setTooltipVisibility).toHaveBeenCalledWith(testGraph, false);
     expect(testGraph.utils.updateLabelVisibility).toHaveBeenCalledWith(
       testGraph,
       false,
@@ -782,6 +781,7 @@ describe("Test GUI loadNodePopup with async and tooltip handling", () => {
       off: jest.fn(),
     };
     testGraph.utils.updateLabelVisibility = jest.fn();
+    testGraph.utils.setTooltipVisibility = jest.fn();
     testGraph.utils.parseUrlFragments = jest.fn(() => ({
       id: new URLSearchParams("id=id&nodeId=node-1"),
     }));
@@ -790,9 +790,7 @@ describe("Test GUI loadNodePopup with async and tooltip handling", () => {
     await testGraph.gui.loadNodePopup(node);
     expect(mockPopup.on).toHaveBeenCalledWith("remove", expect.any(Function));
     mockPopup.handlers.remove();
-    expect(testGraph.echarts.setOption).toHaveBeenCalledWith({
-      media: [{option: {tooltip: {show: true}}}],
-    });
+    expect(testGraph.utils.setTooltipVisibility).toHaveBeenCalledWith(testGraph, true);
     expect(testGraph.utils.updateLabelVisibility).toHaveBeenCalledWith(testGraph, true);
     expect(testGraph.utils.removeUrlFragment).toHaveBeenCalledWith("id", "nodeId");
   });

--- a/test/netjsongraph.dom.test.js
+++ b/test/netjsongraph.dom.test.js
@@ -742,6 +742,45 @@ describe("Test GUI loadNodePopup with async and tooltip handling", () => {
     expect(testGraph.utils.updateLabelVisibility).not.toHaveBeenCalled();
   });
 
+  test("loadNodePopup restores tooltip and labels when replacement content fails", async () => {
+    // Replacement path: a previous popup was open (tooltip already hidden),
+    // we null currentPopup and call previousPopup.remove() so its handler
+    // bails. If new content generation then fails the catch must restore
+    // the tooltip/labels — otherwise the map is stuck in popup-open visual
+    // state with no popup actually visible.
+    const asyncContentHandler = jest.fn(() =>
+      Promise.reject(new Error("Replacement content failed")),
+    );
+    testGraph.setConfig({
+      mapOptions: {
+        nodePopup: {
+          show: true,
+          content: asyncContentHandler,
+          config: {autoPan: true},
+        },
+      },
+      bookmarkableActions: {
+        enabled: true,
+        id: "id",
+      },
+    });
+    testGraph.echarts = {setOption: jest.fn()};
+    testGraph.leaflet = {
+      currentPopup: {remove: jest.fn()},
+      currentPopupRequest: null,
+      once: jest.fn(),
+      off: jest.fn(),
+    };
+    testGraph.utils.updateLabelVisibility = jest.fn();
+    testGraph.utils.setTooltipVisibility = jest.fn();
+    testGraph.utils.removeUrlFragment = jest.fn();
+    const node = {id: "node-1", location: {lat: 10, lng: 20}};
+    await testGraph.gui.loadNodePopup(node);
+    expect(testGraph.utils.setTooltipVisibility).toHaveBeenCalledWith(testGraph, true);
+    expect(testGraph.utils.updateLabelVisibility).toHaveBeenCalledWith(testGraph, true);
+    expect(testGraph.utils.removeUrlFragment).toHaveBeenCalledWith("id", "nodeId");
+  });
+
   test("loadNodePopup catches synchronous custom content errors", async () => {
     const contentHandler = jest.fn(() => {
       throw new Error("Content build failed");

--- a/test/netjsongraph.dom.test.js
+++ b/test/netjsongraph.dom.test.js
@@ -442,3 +442,401 @@ describe("Test GUI on narrow screens", () => {
     expect(graph.gui.nodeLinkInfoContainer.innerHTML).toContain("region");
   });
 });
+
+describe("Test GUI createDefaultPopupContent", () => {
+  beforeEach(() => {
+    graph.gui = new NetJSONGraphGUI(graph);
+  });
+  afterEach(() => {
+    graph.gui = null;
+  });
+  test("Create default popup content with valid location coordinates", () => {
+    const node = {
+      id: "node-1",
+      name: "Test Node",
+      label: "Node Label",
+      location: {
+        lat: 12.3456789,
+        lng: 98.7654321,
+      },
+    };
+    const content = graph.gui.createDefaultPopupContent(node);
+    expect(content).toBeInstanceOf(HTMLElement);
+    expect(content.classList.contains("default-popup")).toBe(true);
+    expect(content.innerHTML).toContain("node-1");
+    expect(content.innerHTML).toContain("Test Node");
+    expect(content.innerHTML).toContain("Node Label");
+    expect(content.innerHTML).toContain("12.34567890");
+    expect(content.innerHTML).toContain("98.76543210");
+  });
+
+  test("Create default popup content with missing location should not display coordinates", () => {
+    const node = {
+      id: "node-2",
+      name: "Test Node No Location",
+      label: "No Location Node",
+    };
+    const content = graph.gui.createDefaultPopupContent(node);
+    expect(content).toBeInstanceOf(HTMLElement);
+    expect(content.innerHTML).toContain("node-2");
+    expect(content.innerHTML).not.toContain("location");
+  });
+
+  test("Create default popup content with null location should not display coordinates", () => {
+    const node = {
+      id: "node-3",
+      name: "Test Node",
+      label: "Node Label",
+      location: null,
+    };
+    const content = graph.gui.createDefaultPopupContent(node);
+    expect(content).toBeInstanceOf(HTMLElement);
+    expect(content.innerHTML).toContain("node-3");
+    expect(content.innerHTML).not.toContain("location");
+  });
+
+  test("Create default popup content with NaN coordinates should not display coordinates", () => {
+    const node = {
+      id: "node-4",
+      name: "Test Node",
+      label: "Node Label",
+      location: {
+        lat: NaN,
+        lng: 98.7654321,
+      },
+    };
+    const content = graph.gui.createDefaultPopupContent(node);
+    expect(content).toBeInstanceOf(HTMLElement);
+    expect(content.innerHTML).toContain("node-4");
+    expect(content.innerHTML).not.toContain("location");
+  });
+
+  test("Create default popup content with Infinity coordinates should not display coordinates", () => {
+    const node = {
+      id: "node-5",
+      name: "Test Node",
+      label: "Node Label",
+      location: {
+        lat: Infinity,
+        lng: 98.7654321,
+      },
+    };
+    const content = graph.gui.createDefaultPopupContent(node);
+    expect(content).toBeInstanceOf(HTMLElement);
+    expect(content.innerHTML).toContain("node-5");
+    expect(content.innerHTML).not.toContain("location");
+  });
+
+  test("Create default popup content with string coordinates should convert and validate", () => {
+    const node = {
+      id: "node-6",
+      name: "Test Node",
+      label: "Node Label",
+      location: {
+        lat: "45.123456",
+        lng: "-87.654321",
+      },
+    };
+    const content = graph.gui.createDefaultPopupContent(node);
+    expect(content).toBeInstanceOf(HTMLElement);
+    expect(content.innerHTML).toContain("45.12345600");
+    expect(content.innerHTML).toContain("-87.65432100");
+  });
+
+  test("Create default popup content with properties.location fallback", () => {
+    const node = {
+      id: "node-7",
+      name: "Test Node",
+      label: "Node Label",
+      properties: {
+        location: {
+          lat: 10.5,
+          lng: 20.5,
+        },
+      },
+    };
+    const content = graph.gui.createDefaultPopupContent(node);
+    expect(content).toBeInstanceOf(HTMLElement);
+    expect(content.innerHTML).toContain("10.50000000");
+    expect(content.innerHTML).toContain("20.50000000");
+  });
+
+  test("Create default popup content with only finite lat should not display coordinates", () => {
+    const node = {
+      id: "node-8",
+      name: "Test Node",
+      label: "Node Label",
+      location: {
+        lat: 45.123,
+        lng: NaN,
+      },
+    };
+    const content = graph.gui.createDefaultPopupContent(node);
+    expect(content).toBeInstanceOf(HTMLElement);
+    expect(content.innerHTML).not.toContain("location");
+  });
+
+  test("Create default popup content with empty node", () => {
+    const node = {};
+    const content = graph.gui.createDefaultPopupContent(node);
+    expect(content).toBeInstanceOf(HTMLElement);
+    expect(content.classList.contains("default-popup")).toBe(true);
+  });
+});
+
+describe("Test GUI loadNodePopup with async and tooltip handling", () => {
+  let testGraph;
+  let container;
+  let originalLeaflet;
+  let mockPopup;
+  let closeButton;
+
+  const mockLeafletPopup = (popupElement) => {
+    mockPopup = {
+      getElement: jest.fn(() => popupElement),
+      setLatLng: jest.fn(() => mockPopup),
+      setContent: jest.fn(() => mockPopup),
+      openOn: jest.fn(() => mockPopup),
+    };
+    window.L = {
+      CRS: {
+        EPSG3857: {},
+      },
+      popup: jest.fn(() => mockPopup),
+    };
+    global.L = window.L;
+  };
+
+  beforeEach(() => {
+    originalLeaflet = window.L;
+    closeButton = {
+      addEventListener: jest.fn(),
+    };
+    mockLeafletPopup({
+      querySelector: jest.fn(() => closeButton),
+    });
+    container = document.createElement("div");
+    container.setAttribute("id", "test-popup-map");
+    document.body.appendChild(container);
+    testGraph = new NetJSONGraphCore({
+      nodes: [{id: "node-1", location: {lat: 10, lng: 20}}],
+      links: [],
+    });
+    testGraph.event = testGraph.utils.createEvent();
+    testGraph.gui = new NetJSONGraphGUI(testGraph);
+    testGraph.setConfig({
+      el: container,
+      mapOptions: {
+        nodePopup: {
+          show: true,
+          content: null,
+          config: {autoPan: true},
+        },
+      },
+      bookmarkableActions: {
+        enabled: true,
+        id: "id",
+      },
+    });
+    testGraph.setUtils();
+  });
+
+  afterEach(() => {
+    if (container && document.body.contains(container)) {
+      document.body.removeChild(container);
+    }
+    window.L = originalLeaflet;
+    global.L = originalLeaflet;
+    testGraph = null;
+  });
+
+  test("loadNodePopup hides tooltip on popup open", async () => {
+    testGraph.echarts = {
+      setOption: jest.fn(),
+    };
+    testGraph.leaflet = {
+      currentPopup: null,
+      once: jest.fn(),
+      off: jest.fn(),
+    };
+    testGraph.utils.updateLabelVisibility = jest.fn();
+    const node = {id: "node-1", location: {lat: 10, lng: 20}};
+    await testGraph.gui.loadNodePopup(node);
+    expect(testGraph.echarts.setOption).toHaveBeenCalledWith({
+      media: [{option: {tooltip: {show: false}}}],
+    });
+    expect(testGraph.utils.updateLabelVisibility).toHaveBeenCalledWith(
+      testGraph,
+      false,
+    );
+  });
+
+  test("loadNodePopup handles async content error and cleans up URL fragment", async () => {
+    const asyncContentHandler = jest.fn(() =>
+      Promise.reject(new Error("Content load failed")),
+    );
+    testGraph.setConfig({
+      mapOptions: {
+        nodePopup: {
+          show: true,
+          content: asyncContentHandler,
+          config: {autoPan: true},
+        },
+      },
+      bookmarkableActions: {
+        enabled: true,
+        id: "id",
+      },
+    });
+    testGraph.echarts = {
+      setOption: jest.fn(),
+    };
+    testGraph.leaflet = {
+      currentPopup: null,
+      currentPopupRequest: null,
+      once: jest.fn(),
+      off: jest.fn(),
+    };
+    testGraph.utils.updateLabelVisibility = jest.fn();
+    testGraph.utils.removeUrlFragment = jest.fn();
+    const node = {id: "node-1", location: {lat: 10, lng: 20}};
+    try {
+      await testGraph.gui.loadNodePopup(node);
+    } catch (e) {
+      // Expected to fail
+    }
+    // Should remove URL fragment on error
+    expect(testGraph.utils.removeUrlFragment).toHaveBeenCalledWith("id", "nodeId");
+  });
+
+  test("loadNodePopup sets up popup close handler to restore tooltip", async () => {
+    testGraph.echarts = {
+      setOption: jest.fn(),
+    };
+    testGraph.leaflet = {
+      currentPopup: null,
+      once: jest.fn(),
+      off: jest.fn(),
+    };
+    testGraph.utils.updateLabelVisibility = jest.fn();
+    const node = {id: "node-1", location: {lat: 10, lng: 20}};
+    await testGraph.gui.loadNodePopup(node);
+    expect(closeButton.addEventListener).toHaveBeenCalledWith(
+      "click",
+      expect.any(Function),
+    );
+    closeButton.addEventListener.mock.calls[0][1]();
+    expect(testGraph.echarts.setOption).toHaveBeenCalledWith({
+      media: [{option: {tooltip: {show: true}}}],
+    });
+    expect(testGraph.utils.updateLabelVisibility).toHaveBeenCalledWith(testGraph, true);
+  });
+
+  test("loadNodePopup handles null popup element gracefully", async () => {
+    testGraph.echarts = {
+      setOption: jest.fn(),
+    };
+    testGraph.leaflet = {
+      currentPopup: null,
+      once: jest.fn(),
+      off: jest.fn(),
+    };
+    testGraph.utils.updateLabelVisibility = jest.fn();
+    mockLeafletPopup(null);
+    const node = {id: "node-1", location: {lat: 10, lng: 20}};
+    await expect(testGraph.gui.loadNodePopup(node)).resolves.toBeUndefined();
+  });
+
+  test("loadNodePopup with async custom content handler that succeeds", async () => {
+    const customContent = "<div>Custom Popup</div>";
+    const asyncContentHandler = jest.fn(() => Promise.resolve(customContent));
+    testGraph.setConfig({
+      mapOptions: {
+        nodePopup: {
+          show: true,
+          content: asyncContentHandler,
+          config: {autoPan: true},
+        },
+      },
+    });
+    testGraph.echarts = {
+      setOption: jest.fn(),
+    };
+    testGraph.leaflet = {
+      currentPopup: null,
+      currentPopupRequest: null,
+      once: jest.fn(),
+      off: jest.fn(),
+    };
+    testGraph.utils.updateLabelVisibility = jest.fn();
+    const node = {id: "node-1", location: {lat: 10, lng: 20}};
+    await testGraph.gui.loadNodePopup(node);
+    // Verify async content was resolved and popup was created with it
+    expect(asyncContentHandler).toHaveBeenCalledWith(node, testGraph);
+    expect(mockPopup.setContent).toHaveBeenCalledWith(customContent);
+  });
+
+  test("loadNodePopup calls onOpen callback if provided", async () => {
+    const onOpenCallback = jest.fn();
+    testGraph.setConfig({
+      mapOptions: {
+        nodePopup: {
+          show: true,
+          content: null,
+          config: {autoPan: true},
+          onOpen: onOpenCallback,
+        },
+      },
+    });
+    testGraph.echarts = {
+      setOption: jest.fn(),
+    };
+    testGraph.leaflet = {
+      currentPopup: null,
+      once: jest.fn(),
+      off: jest.fn(),
+    };
+    testGraph.utils.updateLabelVisibility = jest.fn();
+    testGraph.utils.removeUrlFragment = jest.fn();
+    const node = {id: "node-1", location: {lat: 10, lng: 20}};
+    await testGraph.gui.loadNodePopup(node);
+    // Verify onOpen callback was called
+    expect(onOpenCallback).toHaveBeenCalledWith(testGraph);
+  });
+
+  test("loadNodePopup handles onOpen callback error and cleans up URL fragment", async () => {
+    const onOpenError = new Error("onOpen failed");
+    const onOpenCallback = jest.fn(() => {
+      throw onOpenError;
+    });
+    testGraph.setConfig({
+      mapOptions: {
+        nodePopup: {
+          show: true,
+          content: null,
+          config: {autoPan: true},
+          onOpen: onOpenCallback,
+        },
+      },
+      bookmarkableActions: {
+        enabled: true,
+        id: "id",
+      },
+    });
+    testGraph.echarts = {
+      setOption: jest.fn(),
+    };
+    testGraph.leaflet = {
+      currentPopup: null,
+      once: jest.fn(),
+      off: jest.fn(),
+    };
+    testGraph.utils.updateLabelVisibility = jest.fn();
+    testGraph.utils.removeUrlFragment = jest.fn();
+    global.console.error = jest.fn();
+    const node = {id: "node-1", location: {lat: 10, lng: 20}};
+    await testGraph.gui.loadNodePopup(node);
+    // Verify URL fragment was cleaned up on error
+    expect(testGraph.utils.removeUrlFragment).toHaveBeenCalledWith("id", "nodeId");
+  });
+});

--- a/test/netjsongraph.render.test.js
+++ b/test/netjsongraph.render.test.js
@@ -1,6 +1,11 @@
 import L from "leaflet";
 import NetJSONGraphCore from "../src/js/netjsongraph.core";
 import NetJSONGraphRender from "../src/js/netjsongraph.render";
+import NetJSONGraphGUI from "../src/js/netjsongraph.gui";
+import NetJSONGraphUtil from "../src/js/netjsongraph.util";
+
+const createUpdateLabelVisibilityMock = () =>
+  jest.fn((self, show) => new NetJSONGraphUtil().updateLabelVisibility(self, show));
 
 const JSONFILE = "test";
 const JSONData = {
@@ -512,6 +517,7 @@ describe("generateMapOption - node processing and dynamic styling", () => {
         })),
         parseUrlFragments: jest.fn(),
         setupHashChangeHandler: jest.fn(),
+        updateLabelVisibility: createUpdateLabelVisibilityMock(),
       },
     };
   });
@@ -997,6 +1003,7 @@ describe("Test disableClusteringAtLevel: 0", () => {
         fastDeepCopy: jest.fn((obj) => JSON.parse(JSON.stringify(obj))),
         setupHashChangeHandler: jest.fn(),
         parseUrlFragments: jest.fn(),
+        updateLabelVisibility: createUpdateLabelVisibilityMock(),
       },
       event: {
         emit: jest.fn(),
@@ -1097,6 +1104,7 @@ describe("Test leaflet zoomend handler and zoom control state", () => {
         fastDeepCopy: jest.fn((obj) => JSON.parse(JSON.stringify(obj))),
         parseUrlFragments: jest.fn(),
         setupHashChangeHandler: jest.fn(),
+        updateLabelVisibility: createUpdateLabelVisibilityMock(),
       },
       event: {
         emit: jest.fn(),
@@ -1242,6 +1250,7 @@ describe("mapRender – polygon overlay & moveend bbox logic", () => {
         fastDeepCopy: jest.fn((obj) => JSON.parse(JSON.stringify(obj))),
         parseUrlFragments: jest.fn(),
         setupHashChangeHandler: jest.fn(),
+        updateLabelVisibility: createUpdateLabelVisibilityMock(),
       },
       event: {emit: jest.fn()},
     };
@@ -1307,6 +1316,7 @@ describe("graph label visibility and fallbacks", () => {
         fastDeepCopy: jest.fn((obj) => JSON.parse(JSON.stringify(obj))),
         parseUrlFragments: jest.fn(),
         setupHashChangeHandler: jest.fn(),
+        updateLabelVisibility: createUpdateLabelVisibilityMock(),
       },
       echarts: {
         getOption: jest.fn(() => ({series: [{id: "network-graph", zoom: 1}]})),
@@ -1345,6 +1355,7 @@ describe("graph label visibility and fallbacks", () => {
         fastDeepCopy: jest.fn((obj) => JSON.parse(JSON.stringify(obj))),
         parseUrlFragments: jest.fn(),
         setupHashChangeHandler: jest.fn(),
+        updateLabelVisibility: createUpdateLabelVisibilityMock(),
       },
       echarts: {
         getOption: jest
@@ -1377,6 +1388,7 @@ describe("graph label visibility and fallbacks", () => {
         parseUrlFragments: jest.fn(),
         setupHashChangeHandler: jest.fn(),
         _propagateGraphZoom: jest.fn(),
+        updateLabelVisibility: createUpdateLabelVisibilityMock(),
       },
       echarts: {
         on: jest.fn((evt, cb) => {
@@ -1423,6 +1435,7 @@ describe("map series ids and name fallbacks", () => {
         fastDeepCopy: jest.fn((obj) => JSON.parse(JSON.stringify(obj))),
         parseUrlFragments: jest.fn(),
         setupHashChangeHandler: jest.fn(),
+        updateLabelVisibility: createUpdateLabelVisibilityMock(),
       },
     };
 
@@ -1489,6 +1502,7 @@ describe("map series ids and name fallbacks", () => {
         fastDeepCopy: jest.fn((obj) => JSON.parse(JSON.stringify(obj))),
         parseUrlFragments: jest.fn(),
         setupHashChangeHandler: jest.fn(),
+        updateLabelVisibility: createUpdateLabelVisibilityMock(),
       },
       event: {emit: jest.fn()},
     };
@@ -1555,6 +1569,7 @@ describe("mapRender label and tooltip interaction (emphasis behavior)", () => {
         })),
         echartsSetOption: jest.fn((opt) => mockSelf.echarts.setOption(opt)), // Link to spy
         setupHashChangeHandler: jest.fn(),
+        updateLabelVisibility: createUpdateLabelVisibilityMock(),
       },
       event: {emit: jest.fn()},
     };
@@ -1763,6 +1778,7 @@ describe("mapRender clustering label visibility", () => {
           nonClusterLinks: [],
         })),
         setupHashChangeHandler: jest.fn(),
+        updateLabelVisibility: createUpdateLabelVisibilityMock(),
       },
       event: {emit: jest.fn()},
     };
@@ -1817,5 +1833,141 @@ describe("mapRender clustering label visibility", () => {
     expect(series).toBeDefined();
     expect(series.label.show).toBe(true);
     expect(series.emphasis.label.show).toBe(false);
+  });
+});
+
+describe("Test nodePopup on node and link click", () => {
+  test("nodePopup config with loadNodePopup method exists", () => {
+    const nodePopupTestData = {
+      nodes: [
+        {
+          id: "node-1",
+          location: {lat: 10, lng: 20},
+        },
+      ],
+      links: [],
+    };
+    const container = document.createElement("div");
+    container.setAttribute("id", "map");
+    document.body.appendChild(container);
+    const popupGraph = new NetJSONGraphCore(nodePopupTestData);
+    popupGraph.event = popupGraph.utils.createEvent();
+    popupGraph.setConfig({
+      el: container,
+      mapOptions: {
+        nodePopup: {
+          show: true,
+          content: null,
+          config: {
+            autoPan: true,
+          },
+        },
+      },
+      onClickElement: jest.fn(),
+    });
+    popupGraph.setUtils();
+    popupGraph.gui = new NetJSONGraphGUI(popupGraph);
+    expect(popupGraph.config.mapOptions.nodePopup).toBeDefined();
+    expect(popupGraph.config.mapOptions.nodePopup.show).toBe(true);
+    expect(popupGraph.config.mapOptions.nodePopup.config.autoPan).toBe(true);
+    expect(popupGraph.gui).toBeDefined();
+    expect(popupGraph.gui.loadNodePopup).toBeInstanceOf(Function);
+    document.body.removeChild(container);
+  });
+
+  test("nodePopup disabled in config", () => {
+    const nodePopupTestData2 = {
+      nodes: [
+        {
+          id: "node-1",
+          location: {lat: 10, lng: 20},
+        },
+      ],
+      links: [],
+    };
+    const container = document.createElement("div");
+    container.setAttribute("id", "map-2");
+    document.body.appendChild(container);
+    const disabledPopupGraph = new NetJSONGraphCore(nodePopupTestData2);
+    disabledPopupGraph.event = disabledPopupGraph.utils.createEvent();
+    disabledPopupGraph.setConfig({
+      el: container,
+      mapOptions: {
+        nodePopup: {
+          show: false,
+        },
+      },
+    });
+    disabledPopupGraph.setUtils();
+    expect(disabledPopupGraph.config.mapOptions.nodePopup.show).toBe(false);
+    document.body.removeChild(container);
+  });
+
+  test("createDefaultPopupContent creates valid HTML", () => {
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const defaultPopupGraph = new NetJSONGraphCore({
+      type: "NetworkGraph",
+      nodes: [],
+      links: [],
+    });
+    defaultPopupGraph.event = defaultPopupGraph.utils.createEvent();
+    defaultPopupGraph.gui = new NetJSONGraphGUI(defaultPopupGraph);
+    const node = {
+      id: "test-node",
+      name: "Test Node",
+      label: "Node Label",
+      location: {
+        lat: 45.123456,
+        lng: -87.654321,
+      },
+    };
+    const popupContent = defaultPopupGraph.gui.createDefaultPopupContent(node);
+    expect(popupContent).toBeInstanceOf(HTMLElement);
+    expect(popupContent.classList.contains("default-popup")).toBe(true);
+    expect(popupContent.innerHTML).toContain("test-node");
+    expect(popupContent.innerHTML).toContain("Test Node");
+    expect(popupContent.innerHTML).toContain("Node Label");
+    expect(popupContent.innerHTML).toContain("45.12345600");
+    expect(popupContent.innerHTML).toContain("-87.65432100");
+    document.body.removeChild(container);
+  });
+
+  test("nodePopup configuration includes custom popup content handler", () => {
+    const nodePopupTestData3 = {
+      nodes: [{id: "node-1", location: {lat: 10, lng: 20}}],
+      links: [],
+    };
+    const customContentHandler = jest.fn();
+    const onOpenHandler = jest.fn();
+    const container = document.createElement("div");
+    container.setAttribute("id", "map-3");
+    document.body.appendChild(container);
+    const customPopupGraph = new NetJSONGraphCore(nodePopupTestData3);
+    customPopupGraph.event = customPopupGraph.utils.createEvent();
+    customPopupGraph.setConfig({
+      el: container,
+      mapOptions: {
+        nodePopup: {
+          show: true,
+          content: customContentHandler,
+          config: {
+            autoPan: false,
+            offset: [10, 20],
+          },
+          onOpen: onOpenHandler,
+        },
+      },
+    });
+    customPopupGraph.setUtils();
+    expect(customPopupGraph.config.mapOptions.nodePopup.content).toBe(
+      customContentHandler,
+    );
+    expect(customPopupGraph.config.mapOptions.nodePopup.onOpen).toBe(onOpenHandler);
+    expect(customPopupGraph.config.mapOptions.nodePopup.config.autoPan).toBe(false);
+    expect(customPopupGraph.config.mapOptions.nodePopup.config.offset).toEqual([
+      10, 20,
+    ]);
+    document.body.removeChild(container);
   });
 });

--- a/test/netjsongraph.spec.js
+++ b/test/netjsongraph.spec.js
@@ -200,6 +200,15 @@ describe("NetJSONGraphCore Specification", () => {
         },
       ],
     },
+    nodePopup: {
+      show: false,
+      content: null,
+      config: {
+        autoPan: true,
+        autoPanPadding: [25, 25],
+        offset: null,
+      },
+    },
   };
 
   test("APIs exist", () => {

--- a/test/netjsongraph.spec.js
+++ b/test/netjsongraph.spec.js
@@ -206,7 +206,6 @@ describe("NetJSONGraphCore Specification", () => {
       config: {
         autoPan: true,
         autoPanPadding: [25, 25],
-        offset: null,
       },
     },
   };

--- a/test/netjsongraph.util.test.js
+++ b/test/netjsongraph.util.test.js
@@ -735,6 +735,10 @@ describe("Test removeUrlFragment with paramName argument", () => {
 });
 
 describe("Test updateLabelVisibility utility method", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
   test("updateLabelVisibility hides labels when show is false", () => {
     const util = new NetJSONGraphUtil();
     const mockSelf = {
@@ -874,9 +878,9 @@ describe("Test updateLabelVisibility utility method", () => {
         getZoom: jest.fn(() => 5),
       },
     };
-    global.console.warn = jest.fn();
+    const consoleWarnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
     util.updateLabelVisibility.call(util, mockSelf, true);
-    expect(global.console.warn).toHaveBeenCalledWith(
+    expect(consoleWarnSpy).toHaveBeenCalledWith(
       "updateLabelVisibility: ECharts instance not ready",
     );
   });

--- a/test/netjsongraph.util.test.js
+++ b/test/netjsongraph.util.test.js
@@ -432,3 +432,396 @@ describe("Test move Node in Real Time", () => {
     expect(updated.value).toEqual([newLocation.lng, newLocation.lat]);
   });
 });
+
+describe("Test applyUrlFragmentState with nodePopup", () => {
+  test("calls loadNodePopup when target is null and nodePopup.show is true", () => {
+    const util = new NetJSONGraphUtil();
+    const node = {
+      id: "node-1",
+      location: {lat: 10, lng: 20},
+    };
+    const params = new URLSearchParams();
+    params.set("id", "id");
+    params.set("nodeId", "node-1");
+    const fragments = {
+      id: params,
+    };
+    const mockSelf = {
+      config: {
+        bookmarkableActions: {
+          enabled: true,
+          id: "id",
+          zoomOnRestore: false,
+        },
+        mapOptions: {
+          nodePopup: {
+            show: true,
+          },
+        },
+        onClickElement: jest.fn(),
+      },
+      gui: {
+        loadNodePopup: jest.fn(),
+      },
+      utils: {
+        parseUrlFragments: jest.fn(() => fragments),
+      },
+      nodeLinkIndex: {
+        "node-1": node,
+      },
+      leaflet: {
+        setView: jest.fn(),
+      },
+    };
+    util.applyUrlFragmentState.call(util, mockSelf);
+    expect(mockSelf.gui.loadNodePopup).toHaveBeenCalledWith(node);
+  });
+
+  test("does not call loadNodePopup when target is not null (link case)", () => {
+    const util = new NetJSONGraphUtil();
+    const params = new URLSearchParams();
+    params.set("id", "id");
+    params.set("nodeId", "node-1~node-2");
+    const fragments = {
+      id: params,
+    };
+    const mockSelf = {
+      config: {
+        bookmarkableActions: {
+          enabled: true,
+          id: "id",
+          zoomOnRestore: false,
+        },
+        mapOptions: {
+          nodePopup: {
+            show: true,
+          },
+        },
+        onClickElement: jest.fn(),
+      },
+      gui: {
+        loadNodePopup: jest.fn(),
+      },
+      utils: {
+        parseUrlFragments: jest.fn(() => fragments),
+      },
+      nodeLinkIndex: {
+        "node-1~node-2": {id: "node-1~node-2", location: {lat: 12, lng: 22}},
+      },
+      leaflet: {
+        setView: jest.fn(),
+      },
+    };
+    util.applyUrlFragmentState.call(util, mockSelf);
+    expect(mockSelf.gui.loadNodePopup).not.toHaveBeenCalled();
+  });
+
+  test("does not call loadNodePopup when nodePopup.show is false", () => {
+    const util = new NetJSONGraphUtil();
+    const node = {
+      id: "node-3",
+      location: {lat: 20, lng: 30},
+    };
+    const params = new URLSearchParams();
+    params.set("id", "id");
+    params.set("nodeId", "node-3");
+
+    const fragments = {
+      id: params,
+    };
+    const mockSelf = {
+      config: {
+        bookmarkableActions: {
+          enabled: true,
+          id: "id",
+          zoomOnRestore: false,
+        },
+        mapOptions: {
+          nodePopup: {
+            show: false,
+          },
+        },
+        onClickElement: jest.fn(),
+      },
+      gui: {
+        loadNodePopup: jest.fn(),
+      },
+      utils: {
+        parseUrlFragments: jest.fn(() => fragments),
+      },
+      nodeLinkIndex: {
+        "node-3": node,
+      },
+      leaflet: {
+        setView: jest.fn(),
+      },
+    };
+    util.applyUrlFragmentState.call(util, mockSelf);
+    expect(mockSelf.gui.loadNodePopup).not.toHaveBeenCalled();
+  });
+
+  test("does not call loadNodePopup when mapOptions.nodePopup is not configured", () => {
+    const util = new NetJSONGraphUtil();
+    const node = {
+      id: "node-4",
+      location: {lat: 25, lng: 35},
+    };
+    const params = new URLSearchParams();
+    params.set("id", "id");
+    params.set("nodeId", "node-4");
+    const fragments = {
+      id: params,
+    };
+    const mockSelf = {
+      config: {
+        bookmarkableActions: {
+          enabled: true,
+          id: "id",
+          zoomOnRestore: false,
+        },
+        mapOptions: {},
+        onClickElement: jest.fn(),
+      },
+      gui: {
+        loadNodePopup: jest.fn(),
+      },
+      utils: {
+        parseUrlFragments: jest.fn(() => fragments),
+      },
+      nodeLinkIndex: {
+        "node-4": node,
+      },
+      leaflet: {
+        setView: jest.fn(),
+      },
+    };
+    util.applyUrlFragmentState.call(util, mockSelf);
+    expect(mockSelf.gui.loadNodePopup).not.toHaveBeenCalled();
+  });
+
+  test("calls onClickElement for node clicks regardless of nodePopup setting", () => {
+    const util = new NetJSONGraphUtil();
+    const node = {
+      id: "node-5",
+      location: {lat: 30, lng: 40},
+    };
+    const params = new URLSearchParams();
+    params.set("id", "id");
+    params.set("nodeId", "node-5");
+    const fragments = {
+      id: params,
+    };
+    const mockSelf = {
+      config: {
+        bookmarkableActions: {
+          enabled: true,
+          id: "id",
+          zoomOnRestore: false,
+        },
+        mapOptions: {
+          nodePopup: {
+            show: true,
+          },
+        },
+        onClickElement: jest.fn(),
+      },
+      gui: {
+        loadNodePopup: jest.fn(),
+      },
+      utils: {
+        parseUrlFragments: jest.fn(() => fragments),
+      },
+      nodeLinkIndex: {
+        "node-5": node,
+      },
+      leaflet: {
+        setView: jest.fn(),
+      },
+    };
+    util.applyUrlFragmentState.call(util, mockSelf);
+    expect(mockSelf.config.onClickElement).toHaveBeenCalledWith("node", node);
+  });
+});
+
+describe("Test removeUrlFragment with nodeId parameter", () => {
+  test("removeUrlFragment deletes only specific nodeId when provided", () => {
+    const util = new NetJSONGraphUtil();
+    const params = new URLSearchParams();
+    params.set("nodeId", "node-1");
+    params.set("other", "value");
+    util.parseUrlFragments = jest.fn(() => ({
+      id: params,
+    }));
+    util.updateUrlFragments = jest.fn();
+    util.removeUrlFragment.call(util, "id", "nodeId");
+    expect(util.updateUrlFragments).toHaveBeenCalledWith({id: params}, {id: "id"});
+    expect(params.has("nodeId")).toBe(false);
+    expect(params.get("other")).toBe("value");
+  });
+
+  test("removeUrlFragment deletes entire fragment when nodeId is not provided", () => {
+    const util = new NetJSONGraphUtil();
+    util.parseUrlFragments = jest.fn(() => ({
+      id: new URLSearchParams("nodeId=node-1"),
+    }));
+    util.updateUrlFragments = jest.fn();
+    util.removeUrlFragment.call(util, "id");
+    expect(util.updateUrlFragments).toHaveBeenCalledWith({}, {id: "id"});
+  });
+
+  test("removeUrlFragment returns early when fragment does not exist", () => {
+    const util = new NetJSONGraphUtil();
+    util.parseUrlFragments = jest.fn(() => ({}));
+    util.updateUrlFragments = jest.fn();
+    util.removeUrlFragment.call(util, "nonexistent");
+    expect(util.updateUrlFragments).not.toHaveBeenCalled();
+  });
+});
+
+describe("Test updateLabelVisibility utility method", () => {
+  test("updateLabelVisibility hides labels when show is false", () => {
+    const util = new NetJSONGraphUtil();
+    const mockSelf = {
+      echarts: {
+        setOption: jest.fn(),
+      },
+      config: {
+        showMapLabelsAtZoom: 3,
+      },
+      leaflet: {
+        getZoom: jest.fn(() => 5),
+      },
+    };
+    util.updateLabelVisibility.call(util, mockSelf, false);
+    expect(mockSelf.echarts.setOption).toHaveBeenCalledWith({
+      series: [
+        {
+          id: "geo-map",
+          label: {
+            show: false,
+            silent: true,
+          },
+          emphasis: {
+            label: {
+              show: false,
+            },
+          },
+        },
+      ],
+    });
+  });
+
+  test("updateLabelVisibility shows labels when show is true and zoom >= threshold", () => {
+    const util = new NetJSONGraphUtil();
+    const mockSelf = {
+      echarts: {
+        setOption: jest.fn(),
+      },
+      config: {
+        showMapLabelsAtZoom: 3,
+      },
+      leaflet: {
+        getZoom: jest.fn(() => 5),
+      },
+    };
+    util.updateLabelVisibility.call(util, mockSelf, true);
+    expect(mockSelf.echarts.setOption).toHaveBeenCalledWith({
+      series: [
+        {
+          id: "geo-map",
+          label: {
+            show: true,
+            silent: true,
+          },
+          emphasis: {
+            label: {
+              show: false,
+            },
+          },
+        },
+      ],
+    });
+  });
+
+  test("updateLabelVisibility hides labels when zoom < threshold even if show is true", () => {
+    const util = new NetJSONGraphUtil();
+    const mockSelf = {
+      echarts: {
+        setOption: jest.fn(),
+      },
+      config: {
+        showMapLabelsAtZoom: 10,
+      },
+      leaflet: {
+        getZoom: jest.fn(() => 5),
+      },
+    };
+    util.updateLabelVisibility.call(util, mockSelf, true);
+    expect(mockSelf.echarts.setOption).toHaveBeenCalledWith({
+      series: [
+        {
+          id: "geo-map",
+          label: {
+            show: false,
+            silent: true,
+          },
+          emphasis: {
+            label: {
+              show: false,
+            },
+          },
+        },
+      ],
+    });
+  });
+
+  test("updateLabelVisibility always shows when showMapLabelsAtZoom is false", () => {
+    const util = new NetJSONGraphUtil();
+    const mockSelf = {
+      echarts: {
+        setOption: jest.fn(),
+      },
+      config: {
+        showMapLabelsAtZoom: false,
+      },
+      leaflet: {
+        getZoom: jest.fn(() => 1),
+      },
+    };
+    util.updateLabelVisibility.call(util, mockSelf, true);
+    expect(mockSelf.echarts.setOption).toHaveBeenCalledWith({
+      series: [
+        {
+          id: "geo-map",
+          label: {
+            show: false,
+            silent: true,
+          },
+          emphasis: {
+            label: {
+              show: false,
+            },
+          },
+        },
+      ],
+    });
+  });
+
+  test("updateLabelVisibility returns early when echarts is not ready", () => {
+    const util = new NetJSONGraphUtil();
+    const mockSelf = {
+      echarts: null,
+      config: {
+        showMapLabelsAtZoom: 3,
+      },
+      leaflet: {
+        getZoom: jest.fn(() => 5),
+      },
+    };
+    global.console.warn = jest.fn();
+    util.updateLabelVisibility.call(util, mockSelf, true);
+    expect(global.console.warn).toHaveBeenCalledWith(
+      "updateLabelVisibility: ECharts instance not ready",
+    );
+  });
+});

--- a/test/netjsongraph.util.test.js
+++ b/test/netjsongraph.util.test.js
@@ -835,7 +835,7 @@ describe("Test updateLabelVisibility utility method", () => {
     });
   });
 
-  test("updateLabelVisibility always shows when showMapLabelsAtZoom is false", () => {
+  test("updateLabelVisibility always hides labels when showMapLabelsAtZoom is false", () => {
     const util = new NetJSONGraphUtil();
     const mockSelf = {
       echarts: {
@@ -845,7 +845,7 @@ describe("Test updateLabelVisibility utility method", () => {
         showMapLabelsAtZoom: false,
       },
       leaflet: {
-        getZoom: jest.fn(() => 1),
+        getZoom: jest.fn(() => 10),
       },
     };
     util.updateLabelVisibility.call(util, mockSelf, true);

--- a/test/netjsongraph.util.test.js
+++ b/test/netjsongraph.util.test.js
@@ -599,6 +599,45 @@ describe("Test applyUrlFragmentState with nodePopup", () => {
     expect(mockSelf.gui.loadNodePopup).not.toHaveBeenCalled();
   });
 
+  test("closes the open popup when popstate navigates to a state without nodeId", () => {
+    // Regression for popstate-back to a no-nodeId state: the URL no longer
+    // references a selected node, so any popup that was opened by an earlier
+    // applyUrlFragmentState must be closed to keep the visible state in sync
+    // with the URL.
+    const util = new NetJSONGraphUtil();
+    const fragments = {};
+    const popupRemove = jest.fn();
+    const mockSelf = {
+      config: {
+        bookmarkableActions: {
+          enabled: true,
+          id: "id",
+          zoomOnRestore: false,
+        },
+        mapOptions: {
+          nodePopup: {
+            show: true,
+          },
+        },
+        onClickElement: jest.fn(),
+      },
+      gui: {
+        loadNodePopup: jest.fn(),
+      },
+      utils: {
+        parseUrlFragments: jest.fn(() => fragments),
+      },
+      nodeLinkIndex: {},
+      leaflet: {
+        setView: jest.fn(),
+        currentPopup: {remove: popupRemove},
+      },
+    };
+    util.applyUrlFragmentState.call(util, mockSelf);
+    expect(popupRemove).toHaveBeenCalled();
+    expect(mockSelf.gui.loadNodePopup).not.toHaveBeenCalled();
+  });
+
   test("calls onClickElement for node clicks regardless of nodePopup setting", () => {
     const util = new NetJSONGraphUtil();
     const node = {
@@ -643,10 +682,11 @@ describe("Test applyUrlFragmentState with nodePopup", () => {
   });
 });
 
-describe("Test removeUrlFragment with nodeId parameter", () => {
-  test("removeUrlFragment deletes only specific nodeId when provided", () => {
+describe("Test removeUrlFragment with paramName argument", () => {
+  test("removeUrlFragment deletes only the named param when paramName is provided", () => {
     const util = new NetJSONGraphUtil();
     const params = new URLSearchParams();
+    params.set("id", "id");
     params.set("nodeId", "node-1");
     params.set("other", "value");
     util.parseUrlFragments = jest.fn(() => ({
@@ -659,7 +699,7 @@ describe("Test removeUrlFragment with nodeId parameter", () => {
     expect(params.get("other")).toBe("value");
   });
 
-  test("removeUrlFragment deletes entire fragment when nodeId is not provided", () => {
+  test("removeUrlFragment deletes entire fragment when paramName is not provided", () => {
     const util = new NetJSONGraphUtil();
     util.parseUrlFragments = jest.fn(() => ({
       id: new URLSearchParams("nodeId=node-1"),
@@ -675,6 +715,22 @@ describe("Test removeUrlFragment with nodeId parameter", () => {
     util.updateUrlFragments = jest.fn();
     util.removeUrlFragment.call(util, "nonexistent");
     expect(util.updateUrlFragments).not.toHaveBeenCalled();
+  });
+
+  test("removeUrlFragment drops the whole fragment entry when only the action id remains", () => {
+    // If removing the named param leaves nothing but the bare `id` key, the
+    // fragment becomes a useless stub like "#id=geoMap" — drop it entirely.
+    const util = new NetJSONGraphUtil();
+    const params = new URLSearchParams();
+    params.set("id", "geoMap");
+    params.set("nodeId", "node-1");
+    util.parseUrlFragments = jest.fn(() => ({
+      geoMap: params,
+    }));
+    util.updateUrlFragments = jest.fn();
+    util.removeUrlFragment.call(util, "geoMap", "nodeId");
+    // After deletion, only `id` would remain → entire entry should be gone.
+    expect(util.updateUrlFragments).toHaveBeenCalledWith({}, {id: "geoMap"});
   });
 });
 

--- a/test/netjsongraph.util.test.js
+++ b/test/netjsongraph.util.test.js
@@ -314,7 +314,10 @@ describe("Test URL fragment utilities", () => {
           zoomOnRestore: true,
         },
         graphConfig: {series: {type: null}},
-        mapOptions: {nodeConfig: {type: "scatter"}, center: [0, 0]},
+        mapOptions: {
+          nodeConfig: {type: "scatter"},
+          center: [0, 0],
+        },
         onClickElement: mockOnClick,
       },
       nodeLinkIndex: {n1: node},


### PR DESCRIPTION
Added support for configuring node popup behavior through mapOptions.nodePopup, allowing users to customize popup settings and click behavior through configuration.

Fixes #402

## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- [x] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [x] I have updated the documentation.

## Reference to Existing Issue

Closes #402.

## Description of Changes

```
nodePopup: {
    show: true,
    content:  createCustomPopup,
        config: {
        autoPan: true,
        autoPanPadding: [25, 25],
        offset: null
    }
},
```
- Add the ability to add a pop-up from the config
- Updated netjsonmap-indoormap-overlay.html to be similar to the implementation in monitoring.
- Tested on monitoring with the updated netjsongraph.min.js

## Screenrecording

[Screencast from 2026-05-14 03-49-22.webm](https://github.com/user-attachments/assets/d2fe02f5-613f-4d55-b963-530453b73469)

## Todo
- [x] Add docs
- [x] Fix/Add tests and CI
- [x] Fix bug when pasting the URL on the current tab, the URL is reverting, and the newly pasted URL fragment state is not applied.