### PR TITLE
[chores:fix] Adjust emphasis label behavior when tooltips are enabled

### DIFF
--- a/src/js/netjsongraph.util.js
+++ b/src/js/netjsongraph.util.js
@@ -1492,8 +1492,7 @@ class NetJSONGraphUtil {
       show &&
       self.config.showMapLabelsAtZoom !== false &&
       self.leaflet.getZoom() >= self.config.showMapLabelsAtZoom;
-    const media = self.config.mapOptions?.baseOptions?.media || [];
-    const tooltipEnabled = media.some((item) => item.option?.tooltip?.show === true);
+    const tooltipEnabled = self.echarts.getOption?.()?.tooltip?.[0]?.show === true;
     self.echarts.setOption({
       series: [
         {
@@ -1504,7 +1503,7 @@ class NetJSONGraphUtil {
           },
           emphasis: {
             label: {
-              show: !tooltipEnabled,
+              show: show && !tooltipEnabled,
             },
           },
         },

--- a/src/js/netjsongraph.util.js
+++ b/src/js/netjsongraph.util.js
@@ -1504,7 +1504,7 @@ class NetJSONGraphUtil {
           },
           emphasis: {
             label: {
-              show: showLabel && !tooltipEnabled,
+              show: !tooltipEnabled,
             },
           },
         },

--- a/src/js/netjsongraph.util.js
+++ b/src/js/netjsongraph.util.js
@@ -1492,7 +1492,13 @@ class NetJSONGraphUtil {
       show &&
       self.config.showMapLabelsAtZoom !== false &&
       self.leaflet.getZoom() >= self.config.showMapLabelsAtZoom;
-    const tooltipEnabled = self.echarts.getOption?.()?.tooltip?.[0]?.show === true;
+    const tooltipOption = self.echarts.getOption?.()?.tooltip;
+    const tooltipShow = Array.isArray(tooltipOption)
+      ? tooltipOption[0]?.show
+      : tooltipOption?.show;
+    const tooltipEnabled = tooltipShow === true;
+    const showHoverLabel =
+      show && self.config.showMapLabelsAtZoom !== false && !tooltipEnabled;
     self.echarts.setOption({
       series: [
         {
@@ -1503,7 +1509,7 @@ class NetJSONGraphUtil {
           },
           emphasis: {
             label: {
-              show: show && !tooltipEnabled,
+              show: showHoverLabel,
             },
           },
         },

--- a/src/js/netjsongraph.util.js
+++ b/src/js/netjsongraph.util.js
@@ -1492,6 +1492,8 @@ class NetJSONGraphUtil {
       show &&
       self.config.showMapLabelsAtZoom !== false &&
       self.leaflet.getZoom() >= self.config.showMapLabelsAtZoom;
+    const media = self.config.mapOptions?.baseOptions?.media || [];
+    const tooltipEnabled = media.some((item) => item.option?.tooltip?.show === true);
     self.echarts.setOption({
       series: [
         {
@@ -1502,7 +1504,7 @@ class NetJSONGraphUtil {
           },
           emphasis: {
             label: {
-              show: false,
+              show: showLabel && !tooltipEnabled,
             },
           },
         },

--- a/src/js/netjsongraph.util.js
+++ b/src/js/netjsongraph.util.js
@@ -1492,11 +1492,14 @@ class NetJSONGraphUtil {
       show &&
       self.config.showMapLabelsAtZoom !== false &&
       self.leaflet.getZoom() >= self.config.showMapLabelsAtZoom;
+    // Use ECharts' resolved tooltip state because media rules are applied there.
+    // Tooltip can be returned as either an object or an array.
     const tooltipOption = self.echarts.getOption?.()?.tooltip;
     const tooltipShow = Array.isArray(tooltipOption)
       ? tooltipOption[0]?.show
       : tooltipOption?.show;
     const tooltipEnabled = tooltipShow === true;
+    // Hover labels ignore the zoom threshold, but respect explicit disable and popups.
     const showHoverLabel =
       show && self.config.showMapLabelsAtZoom !== false && !tooltipEnabled;
     self.echarts.setOption({

--- a/test/netjsongraph.browser.test.js
+++ b/test/netjsongraph.browser.test.js
@@ -454,6 +454,40 @@ describe("Chart Rendering Test", () => {
     expect(isVisible).toBe(false);
   });
 
+  test("emphasis labels follow tooltip configuration", async () => {
+    await driver.manage().window().setRect({width: 1200, height: 800});
+    await driver.get(urls.geographicMap);
+    await getElementByCss(driver, ".ec-extension-leaflet", 2000);
+
+    await driver.wait(
+      () => driver.executeScript("return typeof window.map !== 'undefined'"),
+      5000,
+      "Timed out waiting for window.map to initialize",
+    );
+
+    await driver.executeScript(`
+      window.map.config.showMapLabelsAtZoom = 12;
+      window.map.leaflet.setZoom(13);
+      window.map.utils.updateLabelVisibility(window.map, true);
+    `);
+    await driver.sleep(500);
+    let emphasisShow = await driver.executeScript(
+      "return window.map.echarts.getOption().series[0].emphasis.label.show;",
+    );
+    expect(emphasisShow).toBe(false);
+
+    await driver.manage().window().setRect({width: 800, height: 600});
+    await driver.sleep(500);
+    await driver.executeScript(`
+      window.map.utils.updateLabelVisibility(window.map, true);
+    `);
+    await driver.sleep(500);
+    emphasisShow = await driver.executeScript(
+      "return window.map.echarts.getOption().series[0].emphasis.label.show;",
+    );
+    expect(emphasisShow).toBe(true);
+  });
+
   test("moveNodeInRealTime: test in Geographic map example", async () => {
     await driver.get(urls.geographicMap);
     const canvas = await getElementByCss(driver, "canvas", 2000);

--- a/test/netjsongraph.browser.test.js
+++ b/test/netjsongraph.browser.test.js
@@ -459,13 +459,11 @@ describe("Chart Rendering Test", () => {
     try {
       await driver.get(urls.geographicMap);
       await getElementByCss(driver, ".ec-extension-leaflet", 2000);
-
       await driver.wait(
         () => driver.executeScript("return typeof window.map !== 'undefined'"),
         5000,
         "Timed out waiting for window.map to initialize",
       );
-
       await driver.executeScript(`
         window.map.config.showMapLabelsAtZoom = 12;
         window.map.leaflet.setZoom(13);
@@ -476,7 +474,6 @@ describe("Chart Rendering Test", () => {
         "return window.map.echarts.getOption().series[0].emphasis.label.show;",
       );
       expect(emphasisShow).toBe(false);
-
       await driver.manage().window().setRect({width: 800, height: 600});
       await driver.sleep(500);
       await driver.executeScript(`

--- a/test/netjsongraph.browser.test.js
+++ b/test/netjsongraph.browser.test.js
@@ -456,36 +456,40 @@ describe("Chart Rendering Test", () => {
 
   test("emphasis labels follow tooltip configuration", async () => {
     await driver.manage().window().setRect({width: 1200, height: 800});
-    await driver.get(urls.geographicMap);
-    await getElementByCss(driver, ".ec-extension-leaflet", 2000);
+    try {
+      await driver.get(urls.geographicMap);
+      await getElementByCss(driver, ".ec-extension-leaflet", 2000);
 
-    await driver.wait(
-      () => driver.executeScript("return typeof window.map !== 'undefined'"),
-      5000,
-      "Timed out waiting for window.map to initialize",
-    );
+      await driver.wait(
+        () => driver.executeScript("return typeof window.map !== 'undefined'"),
+        5000,
+        "Timed out waiting for window.map to initialize",
+      );
 
-    await driver.executeScript(`
-      window.map.config.showMapLabelsAtZoom = 12;
-      window.map.leaflet.setZoom(13);
-      window.map.utils.updateLabelVisibility(window.map, true);
-    `);
-    await driver.sleep(500);
-    let emphasisShow = await driver.executeScript(
-      "return window.map.echarts.getOption().series[0].emphasis.label.show;",
-    );
-    expect(emphasisShow).toBe(false);
+      await driver.executeScript(`
+        window.map.config.showMapLabelsAtZoom = 12;
+        window.map.leaflet.setZoom(13);
+        window.map.utils.updateLabelVisibility(window.map, true);
+      `);
+      await driver.sleep(500);
+      let emphasisShow = await driver.executeScript(
+        "return window.map.echarts.getOption().series[0].emphasis.label.show;",
+      );
+      expect(emphasisShow).toBe(false);
 
-    await driver.manage().window().setRect({width: 800, height: 600});
-    await driver.sleep(500);
-    await driver.executeScript(`
-      window.map.utils.updateLabelVisibility(window.map, true);
-    `);
-    await driver.sleep(500);
-    emphasisShow = await driver.executeScript(
-      "return window.map.echarts.getOption().series[0].emphasis.label.show;",
-    );
-    expect(emphasisShow).toBe(true);
+      await driver.manage().window().setRect({width: 800, height: 600});
+      await driver.sleep(500);
+      await driver.executeScript(`
+        window.map.utils.updateLabelVisibility(window.map, true);
+      `);
+      await driver.sleep(500);
+      emphasisShow = await driver.executeScript(
+        "return window.map.echarts.getOption().series[0].emphasis.label.show;",
+      );
+      expect(emphasisShow).toBe(true);
+    } finally {
+      await driver.manage().window().setRect({width: 1200, height: 800});
+    }
   });
 
   test("moveNodeInRealTime: test in Geographic map example", async () => {

--- a/test/netjsongraph.render.test.js
+++ b/test/netjsongraph.render.test.js
@@ -1555,6 +1555,9 @@ describe("mapRender label and tooltip interaction (emphasis behavior)", () => {
       },
       leaflet: mockLeaflet,
       echarts: {
+        getOption: jest.fn(() => ({
+          tooltip: [{show: true}],
+        })),
         setOption: jest.fn(),
         on: jest.fn(), // Needed for hover test
         _api: {
@@ -1763,6 +1766,9 @@ describe("mapRender clustering label visibility", () => {
       },
       leaflet: mockLeaflet,
       echarts: {
+        getOption: jest.fn(() => ({
+          tooltip: [{show: true}],
+        })),
         setOption: jest.fn(),
         on: jest.fn(),
         _api: {

--- a/test/netjsongraph.render.test.js
+++ b/test/netjsongraph.render.test.js
@@ -1541,6 +1541,9 @@ describe("mapRender label and tooltip interaction (emphasis behavior)", () => {
       config: {
         geoOptions: {},
         mapOptions: {
+          baseOptions: {
+            media: [{option: {tooltip: {show: true}}}],
+          },
           nodeConfig: {
             label: {show: true},
           },
@@ -1742,7 +1745,13 @@ describe("mapRender clustering label visibility", () => {
       data: {type: "FeatureCollection", features: []},
       config: {
         geoOptions: {},
-        mapOptions: {nodeConfig: {label: {show: true}}, linkConfig: {}},
+        mapOptions: {
+          baseOptions: {
+            media: [{option: {tooltip: {show: true}}}],
+          },
+          nodeConfig: {label: {show: true}},
+          linkConfig: {},
+        },
         mapTileConfig: [{}],
         showMapLabelsAtZoom: 13,
         clustering: true,

--- a/test/netjsongraph.util.test.js
+++ b/test/netjsongraph.util.test.js
@@ -756,7 +756,7 @@ describe("Test updateLabelVisibility utility method", () => {
     jest.restoreAllMocks();
   });
 
-  test("updateLabelVisibility hides labels when show is false", () => {
+  test("updateLabelVisibility hides labels and emphasis labels when show is false", () => {
     const util = new NetJSONGraphUtil();
     const mockSelf = {
       echarts: {
@@ -788,13 +788,50 @@ describe("Test updateLabelVisibility utility method", () => {
     });
   });
 
-  test("updateLabelVisibility shows labels when show is true and zoom >= threshold", () => {
+  test("updateLabelVisibility shows labels and emphasis labels when tooltip is disabled", () => {
     const util = new NetJSONGraphUtil();
     const mockSelf = {
       echarts: {
         setOption: jest.fn(),
       },
       config: {
+        showMapLabelsAtZoom: 3,
+      },
+      leaflet: {
+        getZoom: jest.fn(() => 5),
+      },
+    };
+    util.updateLabelVisibility.call(util, mockSelf, true);
+    expect(mockSelf.echarts.setOption).toHaveBeenCalledWith({
+      series: [
+        {
+          id: "geo-map",
+          label: {
+            show: true,
+            silent: true,
+          },
+          emphasis: {
+            label: {
+              show: true,
+            },
+          },
+        },
+      ],
+    });
+  });
+
+  test("updateLabelVisibility hides emphasis labels when tooltip is enabled", () => {
+    const util = new NetJSONGraphUtil();
+    const mockSelf = {
+      echarts: {
+        setOption: jest.fn(),
+      },
+      config: {
+        mapOptions: {
+          baseOptions: {
+            media: [{option: {tooltip: {show: true}}}],
+          },
+        },
         showMapLabelsAtZoom: 3,
       },
       leaflet: {

--- a/test/netjsongraph.util.test.js
+++ b/test/netjsongraph.util.test.js
@@ -780,7 +780,7 @@ describe("Test updateLabelVisibility utility method", () => {
           },
           emphasis: {
             label: {
-              show: true,
+              show: false,
             },
           },
         },
@@ -792,6 +792,9 @@ describe("Test updateLabelVisibility utility method", () => {
     const util = new NetJSONGraphUtil();
     const mockSelf = {
       echarts: {
+        getOption: jest.fn(() => ({
+          tooltip: [{show: false}],
+        })),
         setOption: jest.fn(),
       },
       config: {
@@ -824,6 +827,9 @@ describe("Test updateLabelVisibility utility method", () => {
     const util = new NetJSONGraphUtil();
     const mockSelf = {
       echarts: {
+        getOption: jest.fn(() => ({
+          tooltip: [{show: true}],
+        })),
         setOption: jest.fn(),
       },
       config: {

--- a/test/netjsongraph.util.test.js
+++ b/test/netjsongraph.util.test.js
@@ -756,7 +756,7 @@ describe("Test updateLabelVisibility utility method", () => {
     jest.restoreAllMocks();
   });
 
-  test("updateLabelVisibility hides labels and emphasis labels when show is false", () => {
+  test("updateLabelVisibility hides labels when show is false", () => {
     const util = new NetJSONGraphUtil();
     const mockSelf = {
       echarts: {
@@ -780,7 +780,7 @@ describe("Test updateLabelVisibility utility method", () => {
           },
           emphasis: {
             label: {
-              show: false,
+              show: true,
             },
           },
         },
@@ -881,7 +881,7 @@ describe("Test updateLabelVisibility utility method", () => {
           },
           emphasis: {
             label: {
-              show: false,
+              show: true,
             },
           },
         },
@@ -913,7 +913,7 @@ describe("Test updateLabelVisibility utility method", () => {
           },
           emphasis: {
             label: {
-              show: false,
+              show: true,
             },
           },
         },

--- a/test/netjsongraph.util.test.js
+++ b/test/netjsongraph.util.test.js
@@ -867,6 +867,9 @@ describe("Test updateLabelVisibility utility method", () => {
     const util = new NetJSONGraphUtil();
     const mockSelf = {
       echarts: {
+        getOption: jest.fn(() => ({
+          tooltip: {show: false},
+        })),
         setOption: jest.fn(),
       },
       config: {
@@ -899,6 +902,9 @@ describe("Test updateLabelVisibility utility method", () => {
     const util = new NetJSONGraphUtil();
     const mockSelf = {
       echarts: {
+        getOption: jest.fn(() => ({
+          tooltip: {show: false},
+        })),
         setOption: jest.fn(),
       },
       config: {
@@ -919,7 +925,7 @@ describe("Test updateLabelVisibility utility method", () => {
           },
           emphasis: {
             label: {
-              show: true,
+              show: false,
             },
           },
         },


### PR DESCRIPTION

## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- [x] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [ ] I have updated the documentation.

## Reference to Existing Issue

Closes #454.

## Description of Changes
- Previous fix https://github.com/openwisp/netjsongraph.js/pull/474 left hardcoded config
```
series: [
        {
          id: "geo-map",
          label: {
            show: showLabel,
            silent: true,
          },
          emphasis: {
            label: {
              show: false, // Here
            },
          },
        },
      ],
``` 
This is making the label hide on hover, as while showing a tooltip, the label is redundant, which was the original issue #454. 

With this hardcoded config, the issue is fixed in the netjsongraph.js examples. However, in monitoring, we use the opposite behavior; we show the label on hover, so we currently override that config there to make it work, which isn’t ideal.

To avoid this, I updated the emphasis value to be determined based on whether the tooltip config is enabled or disabled, so it gets configured correctly in both cases.