### PR TITLE
[feature] Emit Fragmentchange Event on URL Updates #551

### DIFF
--- a/README.md
+++ b/README.md
@@ -594,8 +594,8 @@ NetJSON format used internally is based on [networkgraph](http://netjson.org/rfc
 
   ```js
   window.addEventListener("fragmentchange", (event) => {
-    // event.detail is provided for programmatic URL updates.
-    // On browser back/forward, detail may contain only { source: "popstate" }.
+    // event.detail contains { fragments, state, hash }.
+    // On browser back/forward, it also contains { source: "popstate" }.
     const fragments = netjsongraphInstance.utils.parseUrlFragments();
     // ...open/close overlays, update UI, etc.
   });

--- a/README.md
+++ b/README.md
@@ -588,6 +588,19 @@ NetJSON format used internally is based on [networkgraph](http://netjson.org/rfc
 
   For links, the URL fragment uses the format `source~target` as the `nodeId`. Opening such a URL restores the initial map or graph view and triggers the corresponding link click event.
 
+  When bookmarkable actions are enabled, the library also dispatches a `fragmentchange` event on `window` whenever it updates the URL fragments (after calling `history.pushState`/`history.replaceState`), and also on browser back/forward navigation.
+
+  You can use this event to keep external UI in sync with the URL:
+
+  ```js
+  window.addEventListener("fragmentchange", (event) => {
+    // event.detail is provided for programmatic URL updates.
+    // On browser back/forward, detail may contain only { source: "popstate" }.
+    const fragments = netjsongraphInstance.utils.parseUrlFragments();
+    // ...open/close overlays, update UI, etc.
+  });
+  ```
+
   If you need to manually remove the URL fragment, you can call the built-in utility method: `netjsongraphInstance.utils.removeUrlFragment(bookmarkableActions.id);` where you pass the value of your `bookmarkableActions.id` configuration. You can also remove only a specific parameter from the fragment, for example:
   `netjsongraphInstance.utils.removeUrlFragment(bookmarkableActions.id, "nodeId");`. This removes only the `nodeId` parameter from the URL fragment for that specific map while preserving the remaining fragment state. To keep the fragment itself after removing `nodeId`, make sure to set `bookmarkableActions.preserveFragment = true` otherwise, if no additional parameters remain after removing `nodeId`, the entire fragment will be cleaned up automatically.
 

--- a/public/example_templates/netjsonmap-indoormap-overlay.html
+++ b/public/example_templates/netjsonmap-indoormap-overlay.html
@@ -210,11 +210,10 @@
         openIndoorMap();
       }
 
-      // Registered once at page load so back/forward navigation keeps working
-      // across repeated open/close cycles. A handler installed inside
-      // openIndoorMap that removes itself on close cannot react to a later
-      // forward-nav that should reopen the indoor map.
-      window.addEventListener("popstate", () => {
+      // Keep the overlay in sync with the URL fragments.
+      // NetJSONGraph dispatches `fragmentchange` after calling history.pushState/
+      // history.replaceState, and also on browser back/forward navigation.
+      window.addEventListener("fragmentchange", () => {
         if (getIndoorMapFragment()) {
           if (!document.getElementById("indoormap-container")) {
             openIndoorMap();
@@ -273,10 +272,12 @@
           window._indoorMap = null;
         });
       }
+
       function openIndoorMap() {
         if (window._indoorMap) {
           return window._indoorMap;
         }
+
         let indoorMapContainer = document.getElementById("indoormap-container");
         if (!indoorMapContainer) {
           indoorMapContainer = createIndoorMapContainer();
@@ -411,6 +412,21 @@
               map.fitBounds(bnds);
               map.setMaxBounds(bnds);
               map.invalidateSize();
+
+              // Add the indoor fragment only after the map is initialized.
+              // Use pushState so the overlay-open state becomes its own
+              // back/forward history entry.
+              const fragments = this.utils.parseUrlFragments();
+              if (fragments && !fragments.indoorMap) {
+                const indoorParams = new URLSearchParams();
+                indoorParams.set("id", "indoorMap");
+                fragments.indoorMap = indoorParams;
+                this.utils.updateUrlFragments(
+                  fragments,
+                  {id: "indoorMap"},
+                  false,
+                );
+              }
             },
             onClickElement: disableDefaultSidebar,
           },

--- a/public/example_templates/netjsonmap-indoormap-overlay.html
+++ b/public/example_templates/netjsonmap-indoormap-overlay.html
@@ -214,16 +214,23 @@
       // NetJSONGraph dispatches `fragmentchange` after calling history.pushState/
       // history.replaceState, and also on browser back/forward navigation.
       window.addEventListener("fragmentchange", () => {
-        if (getIndoorMapFragment()) {
-          if (!document.getElementById("indoormap-container")) {
-            openIndoorMap();
+        const hasIndoorFragment = Boolean(getIndoorMapFragment());
+        const isOverlayOpen =
+          document.getElementById("indoormap-container") !== null;
+
+        // No indoor fragment → close overlay if open, then bail.
+        if (!hasIndoorFragment) {
+          if (isOverlayOpen) {
+            document.getElementById("indoormap-container").remove();
+            window._indoorMap = null;
           }
-        } else {
-          const container = document.getElementById("indoormap-container");
-          if (container) {
-            container.remove();
-          }
-          window._indoorMap = null;
+          return;
+        }
+
+        // Indoor fragment present but overlay not open → open it.
+        if (!isOverlayOpen) {
+          openIndoorMap();
+          return;
         }
       });
 
@@ -263,13 +270,32 @@
       function closeButtonHandler(container, indoorMap, onClose) {
         const closeBtn = container.querySelector("#indoormap-close");
         closeBtn.addEventListener("click", () => {
-          const id = indoorMap.config.bookmarkableActions.id;
-          indoorMap.utils.removeUrlFragment(id);
+          // Remove DOM first — then strip the indoor fragment from the URL via
+          // direct replaceState (avoids re-entering fragmentchange while cleanup
+          // is already in progress).
+          container.remove();
+          window._indoorMap = null;
+          const raw = window.location.hash.replace(/^#/, "");
+          if (raw) {
+            const fragments = decodeURIComponent(raw)
+              .split(";")
+              .map((f) => f.trim())
+              .filter(Boolean);
+            const kept = fragments.filter((fragment) => {
+              const params = new URLSearchParams(fragment);
+              return params.get("id") === "geoMap";
+            });
+            const nextHash = kept.length
+              ? `#${encodeURIComponent(kept.join(";"))}`
+              : "";
+            const nextUrl = `${
+              window.location.pathname
+            }${window.location.search}${nextHash}`;
+            window.history.replaceState(null, "", nextUrl);
+          }
           if (typeof onClose === "function") {
             onClose();
           }
-          container.remove();
-          window._indoorMap = null;
         });
       }
 

--- a/public/example_templates/netjsonmap-indoormap-overlay.html
+++ b/public/example_templates/netjsonmap-indoormap-overlay.html
@@ -221,8 +221,10 @@
         // No indoor fragment → close overlay if open, then bail.
         if (!hasIndoorFragment) {
           if (isOverlayOpen) {
-            document.getElementById("indoormap-container").remove();
-            window._indoorMap = null;
+            cleanupIndoorMap(
+              document.getElementById("indoormap-container"),
+              window._indoorMap,
+            );
           }
           return;
         }
@@ -263,11 +265,29 @@
         return container;
       }
 
+      function cleanupIndoorMap(container, indoorMap) {
+        if (indoorMap && indoorMap._popstateHandler) {
+          window.removeEventListener("popstate", indoorMap._popstateHandler);
+          indoorMap._popstateHandler = null;
+        }
+        if (indoorMap?.echarts?.dispose) {
+          indoorMap.echarts.dispose();
+        }
+        if (indoorMap?.leaflet?.remove) {
+          indoorMap.leaflet.remove();
+        }
+        if (container) {
+          container.remove();
+        }
+        if (!indoorMap || window._indoorMap === indoorMap) {
+          window._indoorMap = null;
+        }
+      }
+
       function closeButtonHandler(container, indoorMap, onClose) {
         const closeBtn = container.querySelector("#indoormap-close");
         closeBtn.addEventListener("click", () => {
-          container.remove();
-          window._indoorMap = null;
+          cleanupIndoorMap(container, indoorMap);
           indoorMap.utils.removeUrlFragment("indoorMap");
           if (typeof onClose === "function") {
             onClose();
@@ -336,6 +356,12 @@
               const imageUrl = "../assets/images/floorplan.png";
               img.src = imageUrl;
               await img.decode();
+              if (
+                window._indoorMap !== this ||
+                !document.getElementById("indoormap-container")
+              ) {
+                return;
+              }
               const aspectRatio = img.width / img.height;
               const h = 700;
               const w = h * aspectRatio;

--- a/public/example_templates/netjsonmap-indoormap-overlay.html
+++ b/public/example_templates/netjsonmap-indoormap-overlay.html
@@ -253,46 +253,22 @@
       function createIndoorMapContainer() {
         const container = document.createElement("div");
         container.id = "indoormap-container";
-
         const closeBtn = document.createElement("span");
         closeBtn.id = "indoormap-close";
         closeBtn.innerHTML = "&times;";
-
         const netjsonDiv = document.createElement("div");
         netjsonDiv.id = "netjson-indoormap";
-
         container.appendChild(closeBtn);
         container.appendChild(netjsonDiv);
-
         return container;
       }
 
       function closeButtonHandler(container, indoorMap, onClose) {
         const closeBtn = container.querySelector("#indoormap-close");
         closeBtn.addEventListener("click", () => {
-          // Remove DOM first — then strip the indoor fragment from the URL via
-          // direct replaceState (avoids re-entering fragmentchange while cleanup
-          // is already in progress).
           container.remove();
           window._indoorMap = null;
-          const raw = window.location.hash.replace(/^#/, "");
-          if (raw) {
-            const fragments = decodeURIComponent(raw)
-              .split(";")
-              .map((f) => f.trim())
-              .filter(Boolean);
-            const kept = fragments.filter((fragment) => {
-              const params = new URLSearchParams(fragment);
-              return params.get("id") === "geoMap";
-            });
-            const nextHash = kept.length
-              ? `#${encodeURIComponent(kept.join(";"))}`
-              : "";
-            const nextUrl = `${
-              window.location.pathname
-            }${window.location.search}${nextHash}`;
-            window.history.replaceState(null, "", nextUrl);
-          }
+          indoorMap.utils.removeUrlFragment("indoorMap");
           if (typeof onClose === "function") {
             onClose();
           }
@@ -360,13 +336,10 @@
               const imageUrl = "../assets/images/floorplan.png";
               img.src = imageUrl;
               await img.decode();
-
               const aspectRatio = img.width / img.height;
               const h = 700;
               const w = h * aspectRatio;
-
               const zoom = map.getMaxZoom() - 1;
-
               const anchorLatLng = L.latLng(0, 0);
               const anchorPoint = map.project(anchorLatLng, zoom);
               const topLeft = L.point(
@@ -377,7 +350,6 @@
                 anchorPoint.x + w / 2,
                 anchorPoint.y + h / 2,
               );
-
               const mapOptions = this.echarts.getOption();
               // Refer netjsonmap-indoormap.html for full explanation of this workaround
               // Build an id -> node map so we don't assume the echarts series
@@ -413,7 +385,6 @@
                   sourceNodeProjected,
                   zoom,
                 );
-
                 const target = data.coords[1];
                 const targetPx = Number(target[0]);
                 const targetPy = -Number(target[1]);
@@ -425,7 +396,6 @@
                   targetNodeProjected,
                   zoom,
                 );
-
                 data.coords[0] = [sourceNodeLatLng.lng, sourceNodeLatLng.lat];
                 data.coords[1] = [targetNodeLatLng.lng, targetNodeLatLng.lat];
               });

--- a/public/example_templates/netjsonmap-indoormap-overlay.html
+++ b/public/example_templates/netjsonmap-indoormap-overlay.html
@@ -288,7 +288,7 @@
         const closeBtn = container.querySelector("#indoormap-close");
         closeBtn.addEventListener("click", () => {
           cleanupIndoorMap(container, indoorMap);
-          indoorMap.utils.removeUrlFragment("indoorMap");
+          indoorMap.utils.removeUrlFragment("indoorMap", null, false, false);
           if (typeof onClose === "function") {
             onClose();
           }

--- a/src/js/netjsongraph.util.js
+++ b/src/js/netjsongraph.util.js
@@ -1265,18 +1265,24 @@ class NetJSONGraphUtil {
    * @param {Object.<string, URLSearchParams>} fragments
    * @returns {string}
    */
-  updateUrlFragments(fragments, state) {
+  updateUrlFragments(fragments, state, replace = false) {
     const newHash = Object.values(fragments)
       .map((urlParams) => urlParams.toString())
       .join(";");
 
+    const updateHistory = (hash) => {
+      const method = replace ? "replaceState" : "pushState";
+      window.history[method](state, "", hash);
+      window.dispatchEvent(
+        new CustomEvent("fragmentchange", {
+          detail: {fragments, state, hash: hash.replace(/^#/, "")},
+        }),
+      );
+    };
+
     // Remove dangling "#" when no fragments remain.
     if (!newHash) {
-      window.history.pushState(
-        state,
-        "",
-        window.location.pathname + window.location.search,
-      );
+      updateHistory(window.location.pathname + window.location.search);
       return;
     }
 
@@ -1292,7 +1298,7 @@ class NetJSONGraphUtil {
       (match, key, value) =>
         `${key}=${encodeURIComponent(value.replace(/%7E/gi, "~"))}`,
     );
-    window.history.pushState(state, "", `#${safeHash}`);
+    updateHistory(`#${safeHash}`);
   }
 
   addActionToUrl(self, params) {
@@ -1367,7 +1373,7 @@ class NetJSONGraphUtil {
       delete fragments[id];
     }
     const state = {id};
-    this.updateUrlFragments(fragments, state);
+    this.updateUrlFragments(fragments, state, true);
   }
 
   applyUrlFragmentState(self) {
@@ -1434,6 +1440,11 @@ class NetJSONGraphUtil {
     }
     self._popstateHandler = () => {
       this.applyUrlFragmentState(self);
+      window.dispatchEvent(
+        new CustomEvent("fragmentchange", {
+          detail: {source: "popstate"},
+        }),
+      );
     };
     window.addEventListener("popstate", self._popstateHandler);
     return () => {

--- a/src/js/netjsongraph.util.js
+++ b/src/js/netjsongraph.util.js
@@ -1269,10 +1269,9 @@ class NetJSONGraphUtil {
     const newHash = Object.values(fragments)
       .map((urlParams) => urlParams.toString())
       .join(";");
+    const method = replace ? "replaceState" : "pushState";
 
-    const updateHistory = (hash) => {
-      const method = replace ? "replaceState" : "pushState";
-      window.history[method](state, "", hash);
+    const dispatchFragmentChange = (hash) => {
       window.dispatchEvent(
         new CustomEvent("fragmentchange", {
           detail: {fragments, state, hash: hash.replace(/^#/, "")},
@@ -1282,7 +1281,9 @@ class NetJSONGraphUtil {
 
     // Remove dangling "#" when no fragments remain.
     if (!newHash) {
-      updateHistory(window.location.pathname + window.location.search);
+      const url = window.location.pathname + window.location.search;
+      window.history[method](state, "", url);
+      dispatchFragmentChange("");
       return;
     }
 
@@ -1298,7 +1299,8 @@ class NetJSONGraphUtil {
       (match, key, value) =>
         `${key}=${encodeURIComponent(value.replace(/%7E/gi, "~"))}`,
     );
-    updateHistory(`#${safeHash}`);
+    window.history[method](state, "", `#${safeHash}`);
+    dispatchFragmentChange(`#${safeHash}`);
   }
 
   addActionToUrl(self, params) {
@@ -1438,8 +1440,14 @@ class NetJSONGraphUtil {
     if (self._popstateHandler) {
       window.removeEventListener("popstate", self._popstateHandler);
     }
-    self._popstateHandler = () => {
+    self._popstateHandler = (event) => {
       this.applyUrlFragmentState(self);
+      if (event && event._fragmentchangeDispatched) {
+        return;
+      }
+      if (event) {
+        event._fragmentchangeDispatched = true;
+      }
       window.dispatchEvent(
         new CustomEvent("fragmentchange", {
           detail: {source: "popstate"},

--- a/src/js/netjsongraph.util.js
+++ b/src/js/netjsongraph.util.js
@@ -1355,8 +1355,10 @@ class NetJSONGraphUtil {
    *   from the fragment. If omitted, the whole fragment for the id is dropped.
    * @param {boolean} [preserveFragment] If true, keep a bare id-only fragment
    *   after removing paramName.
+   * @param {boolean} [replace=true] - Whether to use replaceState (true) or
+   *   pushState (false) when updating the URL.
    */
-  removeUrlFragment(id, paramName = null, preserveFragment = false) {
+  removeUrlFragment(id, paramName = null, preserveFragment = false, replace = true) {
     const fragments = this.parseUrlFragments();
     if (!fragments[id]) {
       return;
@@ -1375,7 +1377,7 @@ class NetJSONGraphUtil {
       delete fragments[id];
     }
     const state = {id};
-    this.updateUrlFragments(fragments, state, true);
+    this.updateUrlFragments(fragments, state, replace);
   }
 
   applyUrlFragmentState(self) {
@@ -1442,17 +1444,21 @@ class NetJSONGraphUtil {
     }
     self._popstateHandler = (event) => {
       this.applyUrlFragmentState(self);
-      if (event && event._fragmentchangeDispatched) {
+      if (event && event._fragmentchangePending) {
         return;
       }
       if (event) {
-        event._fragmentchangeDispatched = true;
+        event._fragmentchangePending = true;
       }
-      window.dispatchEvent(
-        new CustomEvent("fragmentchange", {
-          detail: {source: "popstate"},
-        }),
-      );
+      queueMicrotask(() => {
+        const hash = window.location.hash.replace(/^#/, "");
+        const fragments = this.parseUrlFragments();
+        window.dispatchEvent(
+          new CustomEvent("fragmentchange", {
+            detail: {source: "popstate", fragments, state: null, hash},
+          }),
+        );
+      });
     };
     window.addEventListener("popstate", self._popstateHandler);
     return () => {

--- a/test/netjsongraph.browser.test.js
+++ b/test/netjsongraph.browser.test.js
@@ -492,9 +492,16 @@ describe("Chart Rendering Test", () => {
     await driver.navigate().back();
     await driver.sleep(500);
     currentUrl = await driver.getCurrentUrl();
+    expect(currentUrl).toContain("172.16.171.15");
     expect(currentUrl).not.toContain("node_2");
     indoorContainer = await getElementByCss(driver, "#indoormap-container");
     expect(indoorContainer).toBeNull();
+    node = await getElementByXpath(
+      driver,
+      "//span[@class='njg-tooltip-value' and text()='172.16.171.15']",
+      2000,
+    );
+    expect(await node.getAttribute("textContent")).toBe("172.16.171.15");
     await driver.navigate().forward();
     await driver.sleep(500);
     currentUrl = await driver.getCurrentUrl();
@@ -503,6 +510,12 @@ describe("Chart Rendering Test", () => {
     expect(currentUrl).not.toContain("node_2");
     indoorContainer = await getElementByCss(driver, "#indoormap-container");
     expect(indoorContainer).not.toBeNull();
+    node = await getElementByXpath(
+      driver,
+      "//span[@class='njg-tooltip-value' and text()='172.16.171.15']",
+      2000,
+    );
+    expect(await node.getAttribute("textContent")).toBe("172.16.171.15");
 
     // Forward again should restore the indoor node selection.
     await driver.navigate().forward();

--- a/test/netjsongraph.browser.test.js
+++ b/test/netjsongraph.browser.test.js
@@ -390,7 +390,9 @@ describe("Chart Rendering Test", () => {
     expect(currentUrl).toContain("172.16.171.15");
     expect(currentUrl).not.toContain("node_2");
     indoorContainer = await getElementByCss(driver, "#indoormap-container");
-    expect(indoorContainer).toBeNull();
+    // The overlay-open state is a dedicated history entry.
+    // Back from the indoor node selection clears node_2 but keeps the overlay open.
+    expect(indoorContainer).not.toBeNull();
     node = await getElementByXpath(
       driver,
       "//span[@class='njg-tooltip-value' and text()='172.16.171.15']",
@@ -398,6 +400,24 @@ describe("Chart Rendering Test", () => {
     );
     nodeId = await node.getAttribute("textContent");
     expect(nodeId).toBe("172.16.171.15");
+
+    // Back again should close the overlay (no indoorMap fragment).
+    await driver.navigate().back();
+    await driver.sleep(500);
+    currentUrl = await driver.getCurrentUrl();
+    expect(currentUrl).not.toContain("node_2");
+    indoorContainer = await getElementByCss(driver, "#indoormap-container");
+    expect(indoorContainer).toBeNull();
+    await driver.navigate().forward();
+    await driver.sleep(500);
+    currentUrl = await driver.getCurrentUrl();
+    // Forward should reopen the overlay-open state (no node selected).
+    expect(currentUrl).toContain("172.16.171.15");
+    expect(currentUrl).not.toContain("node_2");
+    indoorContainer = await getElementByCss(driver, "#indoormap-container");
+    expect(indoorContainer).not.toBeNull();
+
+    // Forward again should restore the indoor node selection.
     await driver.navigate().forward();
     await driver.sleep(500);
     currentUrl = await driver.getCurrentUrl();

--- a/test/netjsongraph.browser.test.js
+++ b/test/netjsongraph.browser.test.js
@@ -304,6 +304,93 @@ describe("Chart Rendering Test", () => {
     expect(indoorContainer).toBeNull();
   });
 
+  test("bookmarkableActions: indoor overlay removes popstate listener on close", async () => {
+    await driver.get(urls.indoorMapOverlay);
+    const canvas = await getElementByCss(driver, "canvas", 2000);
+    expect(canvas).not.toBeNull();
+    await driver.executeScript(`
+      window._popstateTracker = {added: [], removed: []};
+      const originalAdd = window.addEventListener.bind(window);
+      const originalRemove = window.removeEventListener.bind(window);
+      window._restorePopstateTracker = () => {
+        window.addEventListener = originalAdd;
+        window.removeEventListener = originalRemove;
+      };
+      window.addEventListener = (type, listener, options) => {
+        if (type === "popstate") {
+          window._popstateTracker.added.push(listener);
+        }
+        return originalAdd(type, listener, options);
+      };
+      window.removeEventListener = (type, listener, options) => {
+        if (type === "popstate") {
+          window._popstateTracker.removed.push(listener);
+        }
+        return originalRemove(type, listener, options);
+      };
+    `);
+    await driver.executeScript('window._geoMap.utils.triggerOnClick("172.16.171.15");');
+    const floorplanBtn = await getElementByCss(driver, ".njg-popup-button", 2000);
+    await driver.executeScript("arguments[0].click();", floorplanBtn);
+    const closeBtn = await getElementByCss(driver, "#indoormap-close", 2000);
+    await driver.wait(
+      () => driver.executeScript("return window._popstateTracker.added.length > 0;"),
+      2000,
+    );
+    await closeBtn.click();
+    const popstateStats = await driver.executeScript(`
+      const {added, removed} = window._popstateTracker;
+      window._restorePopstateTracker();
+      return {
+        added: added.length,
+        leaked: added.filter((listener) => !removed.includes(listener)).length,
+      };
+    `);
+    expect(popstateStats.added).toBeGreaterThan(0);
+    expect(popstateStats.leaked).toBe(0);
+  });
+
+  test("bookmarkableActions: closing indoor overlay during image decode keeps it closed", async () => {
+    await driver.get(urls.indoorMapOverlay);
+    const canvas = await getElementByCss(driver, "canvas", 2000);
+    expect(canvas).not.toBeNull();
+    await driver.executeScript(`
+      const originalDecode = Image.prototype.decode;
+      window._restoreIndoorImageDecode = () => {
+        Image.prototype.decode = originalDecode;
+      };
+      Image.prototype.decode = function () {
+        if (this.src.includes("floorplan.png")) {
+          return new Promise((resolve) => {
+            window._resolveIndoorImageDecode = resolve;
+          });
+        }
+        return originalDecode.call(this);
+      };
+    `);
+    await driver.executeScript('window._geoMap.utils.triggerOnClick("172.16.171.15");');
+    const floorplanBtn = await getElementByCss(driver, ".njg-popup-button", 2000);
+    await driver.executeScript("arguments[0].click();", floorplanBtn);
+    const closeBtn = await getElementByCss(driver, "#indoormap-close", 2000);
+    await driver.wait(
+      () =>
+        driver.executeScript(
+          "return typeof window._resolveIndoorImageDecode === 'function';",
+        ),
+      2000,
+    );
+    await closeBtn.click();
+    await driver.executeScript(`
+      window._resolveIndoorImageDecode();
+      window._restoreIndoorImageDecode();
+    `);
+    await driver.sleep(500);
+    const currentUrl = await driver.getCurrentUrl();
+    const indoorContainer = await getElementByCss(driver, "#indoormap-container");
+    expect(currentUrl).not.toContain("id=indoorMap");
+    expect(indoorContainer).toBeNull();
+  });
+
   test("bookmarkableActions: test url fragments for nodes", async () => {
     await driver.get(`${urls.indoorMapOverlay}#id=geoMap&nodeId=172.16.177.33`);
     const canvas = await getElementByCss(driver, "canvas", 2000);

--- a/test/netjsongraph.util.test.js
+++ b/test/netjsongraph.util.test.js
@@ -694,7 +694,11 @@ describe("Test removeUrlFragment with paramName argument", () => {
     }));
     util.updateUrlFragments = jest.fn();
     util.removeUrlFragment.call(util, "id", "nodeId");
-    expect(util.updateUrlFragments).toHaveBeenCalledWith({id: params}, {id: "id"});
+    expect(util.updateUrlFragments).toHaveBeenCalledWith(
+      {id: params},
+      {id: "id"},
+      true,
+    );
     expect(params.has("nodeId")).toBe(false);
     expect(params.get("other")).toBe("value");
   });
@@ -706,7 +710,7 @@ describe("Test removeUrlFragment with paramName argument", () => {
     }));
     util.updateUrlFragments = jest.fn();
     util.removeUrlFragment.call(util, "id");
-    expect(util.updateUrlFragments).toHaveBeenCalledWith({}, {id: "id"});
+    expect(util.updateUrlFragments).toHaveBeenCalledWith({}, {id: "id"}, true);
   });
 
   test("removeUrlFragment returns early when fragment does not exist", () => {
@@ -730,7 +734,7 @@ describe("Test removeUrlFragment with paramName argument", () => {
     util.updateUrlFragments = jest.fn();
     util.removeUrlFragment.call(util, "geoMap", "nodeId");
     // After deletion, only `id` would remain → entire entry should be gone.
-    expect(util.updateUrlFragments).toHaveBeenCalledWith({}, {id: "geoMap"});
+    expect(util.updateUrlFragments).toHaveBeenCalledWith({}, {id: "geoMap"}, true);
   });
 
   test("removeUrlFragment keeps an id-only fragment when preserveFragment is true", () => {
@@ -746,8 +750,183 @@ describe("Test removeUrlFragment with paramName argument", () => {
     expect(util.updateUrlFragments).toHaveBeenCalledWith(
       {geoMap: params},
       {id: "geoMap"},
+      true,
     );
     expect(params.toString()).toBe("id=geoMap");
+  });
+});
+
+describe("Test updateUrlFragments fragmentchange event", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+    window.location.hash = "";
+  });
+
+  test("calls pushState when replace=false (default)", () => {
+    const util = new NetJSONGraphUtil();
+    const params = new URLSearchParams();
+    params.set("id", "test");
+    params.set("nodeId", "node-1");
+    const fragments = {test: params};
+    const state = {some: "state"};
+
+    const pushSpy = jest.spyOn(window.history, "pushState");
+    const replaceSpy = jest.spyOn(window.history, "replaceState");
+
+    util.updateUrlFragments(fragments, state);
+
+    expect(pushSpy).toHaveBeenCalledWith(state, "", `#${params.toString()}`);
+    expect(replaceSpy).not.toHaveBeenCalled();
+  });
+
+  test("calls replaceState when replace=true", () => {
+    const util = new NetJSONGraphUtil();
+    const params = new URLSearchParams();
+    params.set("id", "test");
+    params.set("nodeId", "node-1");
+    const fragments = {test: params};
+    const state = {some: "state"};
+
+    const pushSpy = jest.spyOn(window.history, "pushState");
+    const replaceSpy = jest.spyOn(window.history, "replaceState");
+
+    util.updateUrlFragments(fragments, state, true);
+
+    expect(replaceSpy).toHaveBeenCalledWith(state, "", `#${params.toString()}`);
+    expect(pushSpy).not.toHaveBeenCalled();
+  });
+
+  test("dispatches fragmentchange with hash when fragments present", () => {
+    const util = new NetJSONGraphUtil();
+    const params = new URLSearchParams();
+    params.set("id", "test");
+    params.set("nodeId", "node-1");
+    const fragments = {test: params};
+    const state = {some: "state"};
+
+    jest.spyOn(window.history, "pushState").mockImplementation(() => {});
+    const dispatchSpy = jest.spyOn(window, "dispatchEvent");
+
+    util.updateUrlFragments(fragments, state);
+
+    expect(dispatchSpy).toHaveBeenCalledTimes(1);
+    const event = dispatchSpy.mock.calls[0][0];
+    expect(event.type).toBe("fragmentchange");
+    expect(event.detail).toEqual({
+      fragments,
+      state,
+      hash: params.toString(),
+    });
+  });
+
+  test("dispatches fragmentchange with empty hash when no fragments remain", () => {
+    const util = new NetJSONGraphUtil();
+    const state = {some: "state"};
+
+    jest.spyOn(window.history, "pushState").mockImplementation(() => {});
+    const dispatchSpy = jest.spyOn(window, "dispatchEvent");
+
+    util.updateUrlFragments({}, state);
+
+    const event = dispatchSpy.mock.calls[0][0];
+    expect(event.type).toBe("fragmentchange");
+    expect(event.detail.hash).toBe(window.location.pathname + window.location.search);
+  });
+
+  test("dispatches fragmentchange on replaceState too", () => {
+    const util = new NetJSONGraphUtil();
+    const params = new URLSearchParams();
+    params.set("id", "test");
+    const fragments = {test: params};
+    const state = {some: "state"};
+
+    jest.spyOn(window.history, "replaceState").mockImplementation(() => {});
+    const dispatchSpy = jest.spyOn(window, "dispatchEvent");
+
+    util.updateUrlFragments(fragments, state, true);
+
+    expect(dispatchSpy).toHaveBeenCalledTimes(1);
+    const event = dispatchSpy.mock.calls[0][0];
+    expect(event.type).toBe("fragmentchange");
+  });
+
+  test("clears hash when no fragments remain", () => {
+    const util = new NetJSONGraphUtil();
+    const state = {some: "state"};
+
+    const pushSpy = jest.spyOn(window.history, "pushState");
+    jest.spyOn(window, "dispatchEvent").mockImplementation(() => true);
+
+    util.updateUrlFragments({}, state);
+
+    const url = pushSpy.mock.calls[0][2];
+    expect(url).toBe(window.location.pathname + window.location.search);
+  });
+});
+
+describe("Test setupHashChangeHandler fragmentchange event", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test("registers popstate listener", () => {
+    const util = new NetJSONGraphUtil();
+    /* eslint-disable no-underscore-dangle */
+    const self = {_popstateHandler: null};
+    const addSpy = jest.spyOn(window, "addEventListener");
+
+    util.setupHashChangeHandler(self);
+
+    expect(addSpy).toHaveBeenCalledWith("popstate", expect.any(Function));
+    expect(typeof self._popstateHandler).toBe("function");
+  });
+
+  test("removes duplicate listener on second call", () => {
+    const util = new NetJSONGraphUtil();
+    const oldHandler = jest.fn();
+    const self = {_popstateHandler: oldHandler};
+    const removeSpy = jest.spyOn(window, "removeEventListener");
+    jest.spyOn(window, "addEventListener").mockImplementation(() => {});
+
+    util.setupHashChangeHandler(self);
+
+    expect(removeSpy).toHaveBeenCalledWith("popstate", oldHandler);
+    expect(self._popstateHandler).not.toBe(oldHandler);
+  });
+
+  test("popstate handler calls applyUrlFragmentState and dispatches fragmentchange", () => {
+    const util = new NetJSONGraphUtil();
+    const self = {_popstateHandler: null};
+
+    const applySpy = jest
+      .spyOn(util, "applyUrlFragmentState")
+      .mockImplementation(() => {});
+    jest.spyOn(window, "addEventListener").mockImplementation(() => {});
+    const dispatchSpy = jest.spyOn(window, "dispatchEvent");
+
+    util.setupHashChangeHandler(self);
+    self._popstateHandler();
+
+    expect(applySpy).toHaveBeenCalledWith(self);
+    const event = dispatchSpy.mock.calls[0][0];
+    expect(event.type).toBe("fragmentchange");
+    expect(event.detail).toEqual({source: "popstate"});
+  });
+
+  test("teardown removes listener and clears handler", () => {
+    const util = new NetJSONGraphUtil();
+    const self = {_popstateHandler: null};
+
+    jest.spyOn(window, "addEventListener").mockImplementation(() => {});
+    const removeSpy = jest.spyOn(window, "removeEventListener");
+
+    const teardown = util.setupHashChangeHandler(self);
+    const handler = self._popstateHandler;
+    teardown();
+
+    expect(removeSpy).toHaveBeenCalledWith("popstate", handler);
+    expect(self._popstateHandler).toBeNull();
+    /* eslint-enable no-underscore-dangle */
   });
 });
 

--- a/test/netjsongraph.util.test.js
+++ b/test/netjsongraph.util.test.js
@@ -141,7 +141,6 @@ describe("makeCluster cluster separation logic", () => {
 describe("Test utils deepCopy function", () => {
   test("creates a deep clone that is independent from the original object", () => {
     const util = new NetJSONGraphUtil();
-
     const config = {
       render: "map",
       mapOptions: {
@@ -156,14 +155,11 @@ describe("Test utils deepCopy function", () => {
         },
       ],
     };
-
     const original = config;
     const clone = util.deepCopy(original);
-
     expect(clone).not.toBe(original);
     expect(clone.mapOptions).not.toBe(original.mapOptions);
     expect(clone.linkCategories).not.toBe(original.linkCategories);
-
     clone.render = "graph";
     clone.mapOptions.center = [0, 0];
     clone.mapOptions.zoom = 10;
@@ -172,7 +168,6 @@ describe("Test utils deepCopy function", () => {
       name: "up",
       linkStyle: {color: "#00ff00", width: 2},
     });
-
     expect(original.render).toBe("map");
     expect(clone.render).toBe("graph");
     expect(original.mapOptions.center).toEqual([50, 50]);
@@ -191,12 +186,10 @@ describe("Test utils deepCopy function", () => {
 
 describe("Test URL fragment utilities", () => {
   let utils;
-
   beforeEach(() => {
     utils = new NetJSONGraphUtil();
     window.location.hash = "";
   });
-
   afterEach(() => {
     window.location.hash = "";
   });
@@ -204,7 +197,6 @@ describe("Test URL fragment utilities", () => {
   test("Test parseUrlFragments parses multiple fragments and decodes values", () => {
     window.location.hash = "#id=geoMap&nodeId=abc%3A123;id=indoorMap&nodeId=indoorNode";
     const fragments = utils.parseUrlFragments();
-
     expect(Object.keys(fragments).sort()).toEqual(["geoMap", "indoorMap"].sort());
     expect(fragments.geoMap.get("nodeId")).toBe("abc:123");
     expect(fragments.indoorMap.get("nodeId")).toBe("indoorNode");
@@ -224,9 +216,7 @@ describe("Test URL fragment utilities", () => {
       dataType: "node",
       data: {id: "node1"},
     };
-
     utils.addActionToUrl(self, params);
-
     const fragments = utils.parseUrlFragments();
     expect(fragments.basicUsage).toBeDefined();
     expect(fragments.basicUsage.get("id")).toBe("basicUsage");
@@ -243,14 +233,11 @@ describe("Test URL fragment utilities", () => {
       utils: {...utils, graphRender: "graph", mapRender: "map"},
       nodeLinkIndex: {"node1~node2": link},
     };
-
     const params = {
       dataType: "edge",
       data: link,
     };
-
     utils.addActionToUrl(self, params);
-
     const fragments = utils.parseUrlFragments();
     expect(fragments.basicUsage).toBeDefined();
     expect(fragments.basicUsage.get("id")).toBe("basicUsage");
@@ -275,10 +262,8 @@ describe("Test URL fragment utilities", () => {
       dataType: "node",
       data: {id: "node1"},
     };
-
     utils.addActionToUrl(self, params);
     const fragments = utils.parseUrlFragments();
-
     expect(fragments.graph).toBeDefined();
     expect(fragments.graph.get("nodeId")).toBe("node1");
     expect(fragments.geo).toBeDefined();
@@ -297,13 +282,11 @@ describe("Test URL fragment utilities", () => {
   test("applyUrlFragmentState calls map.setView and triggers onClickElement", () => {
     const mockSetView = jest.fn();
     const mockOnClick = jest.fn();
-
     const node = {
       id: "n1",
       location: {lat: 12.1, lng: 77.5},
       cluster: null,
     };
-
     const self = {
       config: {
         render: "map",
@@ -324,17 +307,14 @@ describe("Test URL fragment utilities", () => {
       leaflet: {setView: mockSetView},
       utils,
     };
-
     window.location.hash = "#id=geo&nodeId=n1";
     utils.applyUrlFragmentState(self);
-
     expect(mockSetView).toHaveBeenCalledWith([12.1, 77.5], 6);
     expect(mockOnClick).toHaveBeenCalledWith("node", node);
   });
 
   test("Test applyUrlFragmentState runs only after onReady completes", async () => {
     const recorder = [];
-
     const emitter = {
       handlers: {},
       once(event, handler) {
@@ -351,13 +331,11 @@ describe("Test URL fragment utilities", () => {
       new Promise((resolve) => {
         setTimeout(resolve, ms);
       });
-
     const asyncOnReady = async () => {
       recorder.push("onReady-start");
       await delay(20);
       recorder.push("onReady-done");
     };
-
     const onReadyDone = new Promise((resolve) => {
       emitter.once("onReady", async () => {
         await asyncOnReady();
@@ -417,14 +395,11 @@ describe("Test move Node in Real Time", () => {
     util.moveNodeInRealTime.call(mapContext, node.id, newLocation);
     expect(echarts.getOption).toHaveBeenCalled();
     expect(echarts.setOption).toHaveBeenCalled();
-
     const calledArg = echarts.setOption.mock.calls[0][0];
     expect(calledArg).toBeDefined();
     expect(calledArg.series).toBeDefined();
-
     const scatterSeries = calledArg.series.find((s) => s.type === "scatter");
     expect(scatterSeries).toBeDefined();
-
     const updated = scatterSeries.data.find((d) => d.node.id === node.id);
     expect(updated).toBeDefined();
     expect(updated.node.location).toEqual(newLocation);
@@ -769,12 +744,9 @@ describe("Test updateUrlFragments fragmentchange event", () => {
     params.set("nodeId", "node-1");
     const fragments = {test: params};
     const state = {some: "state"};
-
     const pushSpy = jest.spyOn(window.history, "pushState");
     const replaceSpy = jest.spyOn(window.history, "replaceState");
-
     util.updateUrlFragments(fragments, state);
-
     expect(pushSpy).toHaveBeenCalledWith(state, "", `#${params.toString()}`);
     expect(replaceSpy).not.toHaveBeenCalled();
   });
@@ -786,12 +758,9 @@ describe("Test updateUrlFragments fragmentchange event", () => {
     params.set("nodeId", "node-1");
     const fragments = {test: params};
     const state = {some: "state"};
-
     const pushSpy = jest.spyOn(window.history, "pushState");
     const replaceSpy = jest.spyOn(window.history, "replaceState");
-
     util.updateUrlFragments(fragments, state, true);
-
     expect(replaceSpy).toHaveBeenCalledWith(state, "", `#${params.toString()}`);
     expect(pushSpy).not.toHaveBeenCalled();
   });
@@ -803,12 +772,9 @@ describe("Test updateUrlFragments fragmentchange event", () => {
     params.set("nodeId", "node-1");
     const fragments = {test: params};
     const state = {some: "state"};
-
     jest.spyOn(window.history, "pushState").mockImplementation(() => {});
     const dispatchSpy = jest.spyOn(window, "dispatchEvent");
-
     util.updateUrlFragments(fragments, state);
-
     expect(dispatchSpy).toHaveBeenCalledTimes(1);
     const event = dispatchSpy.mock.calls[0][0];
     expect(event.type).toBe("fragmentchange");
@@ -822,15 +788,12 @@ describe("Test updateUrlFragments fragmentchange event", () => {
   test("dispatches fragmentchange with empty hash when no fragments remain", () => {
     const util = new NetJSONGraphUtil();
     const state = {some: "state"};
-
     jest.spyOn(window.history, "pushState").mockImplementation(() => {});
     const dispatchSpy = jest.spyOn(window, "dispatchEvent");
-
     util.updateUrlFragments({}, state);
-
     const event = dispatchSpy.mock.calls[0][0];
     expect(event.type).toBe("fragmentchange");
-    expect(event.detail.hash).toBe(window.location.pathname + window.location.search);
+    expect(event.detail.hash).toBe("");
   });
 
   test("dispatches fragmentchange on replaceState too", () => {
@@ -839,12 +802,9 @@ describe("Test updateUrlFragments fragmentchange event", () => {
     params.set("id", "test");
     const fragments = {test: params};
     const state = {some: "state"};
-
     jest.spyOn(window.history, "replaceState").mockImplementation(() => {});
     const dispatchSpy = jest.spyOn(window, "dispatchEvent");
-
     util.updateUrlFragments(fragments, state, true);
-
     expect(dispatchSpy).toHaveBeenCalledTimes(1);
     const event = dispatchSpy.mock.calls[0][0];
     expect(event.type).toBe("fragmentchange");
@@ -853,12 +813,9 @@ describe("Test updateUrlFragments fragmentchange event", () => {
   test("clears hash when no fragments remain", () => {
     const util = new NetJSONGraphUtil();
     const state = {some: "state"};
-
     const pushSpy = jest.spyOn(window.history, "pushState");
     jest.spyOn(window, "dispatchEvent").mockImplementation(() => true);
-
     util.updateUrlFragments({}, state);
-
     const url = pushSpy.mock.calls[0][2];
     expect(url).toBe(window.location.pathname + window.location.search);
   });
@@ -874,9 +831,7 @@ describe("Test setupHashChangeHandler fragmentchange event", () => {
     /* eslint-disable no-underscore-dangle */
     const self = {_popstateHandler: null};
     const addSpy = jest.spyOn(window, "addEventListener");
-
     util.setupHashChangeHandler(self);
-
     expect(addSpy).toHaveBeenCalledWith("popstate", expect.any(Function));
     expect(typeof self._popstateHandler).toBe("function");
   });
@@ -887,9 +842,7 @@ describe("Test setupHashChangeHandler fragmentchange event", () => {
     const self = {_popstateHandler: oldHandler};
     const removeSpy = jest.spyOn(window, "removeEventListener");
     jest.spyOn(window, "addEventListener").mockImplementation(() => {});
-
     util.setupHashChangeHandler(self);
-
     expect(removeSpy).toHaveBeenCalledWith("popstate", oldHandler);
     expect(self._popstateHandler).not.toBe(oldHandler);
   });
@@ -897,33 +850,50 @@ describe("Test setupHashChangeHandler fragmentchange event", () => {
   test("popstate handler calls applyUrlFragmentState and dispatches fragmentchange", () => {
     const util = new NetJSONGraphUtil();
     const self = {_popstateHandler: null};
-
     const applySpy = jest
       .spyOn(util, "applyUrlFragmentState")
       .mockImplementation(() => {});
     jest.spyOn(window, "addEventListener").mockImplementation(() => {});
     const dispatchSpy = jest.spyOn(window, "dispatchEvent");
-
     util.setupHashChangeHandler(self);
-    self._popstateHandler();
-
+    const popstateEvent = {};
+    self._popstateHandler(popstateEvent);
     expect(applySpy).toHaveBeenCalledWith(self);
+    expect(dispatchSpy).toHaveBeenCalledTimes(1);
     const event = dispatchSpy.mock.calls[0][0];
     expect(event.type).toBe("fragmentchange");
     expect(event.detail).toEqual({source: "popstate"});
   });
 
+  test("dispatches fragmentchange only once across multiple instances on same popstate event", () => {
+    const util1 = new NetJSONGraphUtil();
+    const util2 = new NetJSONGraphUtil();
+    const self1 = {_popstateHandler: null};
+    const self2 = {_popstateHandler: null};
+    jest.spyOn(util1, "applyUrlFragmentState").mockImplementation(() => {});
+    jest.spyOn(util2, "applyUrlFragmentState").mockImplementation(() => {});
+    jest.spyOn(window, "addEventListener").mockImplementation(() => {});
+    const dispatchSpy = jest.spyOn(window, "dispatchEvent");
+    util1.setupHashChangeHandler(self1);
+    util2.setupHashChangeHandler(self2);
+    const popstateEvent = {};
+    self1._popstateHandler(popstateEvent);
+    self2._popstateHandler(popstateEvent);
+    expect(util1.applyUrlFragmentState).toHaveBeenCalledWith(self1);
+    expect(util2.applyUrlFragmentState).toHaveBeenCalledWith(self2);
+    expect(dispatchSpy).toHaveBeenCalledTimes(1);
+    const event = dispatchSpy.mock.calls[0][0];
+    expect(event.type).toBe("fragmentchange");
+  });
+
   test("teardown removes listener and clears handler", () => {
     const util = new NetJSONGraphUtil();
     const self = {_popstateHandler: null};
-
     jest.spyOn(window, "addEventListener").mockImplementation(() => {});
     const removeSpy = jest.spyOn(window, "removeEventListener");
-
     const teardown = util.setupHashChangeHandler(self);
     const handler = self._popstateHandler;
     teardown();
-
     expect(removeSpy).toHaveBeenCalledWith("popstate", handler);
     expect(self._popstateHandler).toBeNull();
     /* eslint-enable no-underscore-dangle */

--- a/test/netjsongraph.util.test.js
+++ b/test/netjsongraph.util.test.js
@@ -729,6 +729,16 @@ describe("Test removeUrlFragment with paramName argument", () => {
     );
     expect(params.toString()).toBe("id=geoMap");
   });
+
+  test("removeUrlFragment uses pushState when replace=false", () => {
+    const util = new NetJSONGraphUtil();
+    util.parseUrlFragments = jest.fn(() => ({
+      indoorMap: new URLSearchParams("id=indoorMap"),
+    }));
+    util.updateUrlFragments = jest.fn();
+    util.removeUrlFragment.call(util, "indoorMap", null, false, false);
+    expect(util.updateUrlFragments).toHaveBeenCalledWith({}, {id: "indoorMap"}, false);
+  });
 });
 
 describe("Test updateUrlFragments fragmentchange event", () => {
@@ -847,7 +857,7 @@ describe("Test setupHashChangeHandler fragmentchange event", () => {
     expect(self._popstateHandler).not.toBe(oldHandler);
   });
 
-  test("popstate handler calls applyUrlFragmentState and dispatches fragmentchange", () => {
+  test("popstate handler calls applyUrlFragmentState and dispatches fragmentchange", async () => {
     const util = new NetJSONGraphUtil();
     const self = {_popstateHandler: null};
     const applySpy = jest
@@ -859,13 +869,20 @@ describe("Test setupHashChangeHandler fragmentchange event", () => {
     const popstateEvent = {};
     self._popstateHandler(popstateEvent);
     expect(applySpy).toHaveBeenCalledWith(self);
+    // Dispatch is deferred via queueMicrotask — not yet called
+    expect(dispatchSpy).not.toHaveBeenCalled();
+    // Flush microtasks
+    await Promise.resolve();
     expect(dispatchSpy).toHaveBeenCalledTimes(1);
     const event = dispatchSpy.mock.calls[0][0];
     expect(event.type).toBe("fragmentchange");
-    expect(event.detail).toEqual({source: "popstate"});
+    expect(event.detail.source).toBe("popstate");
+    expect(event.detail.fragments).toBeDefined();
+    expect(event.detail.state).toBeNull();
+    expect(typeof event.detail.hash).toBe("string");
   });
 
-  test("dispatches fragmentchange only once across multiple instances on same popstate event", () => {
+  test("dispatches fragmentchange only once across multiple instances on same popstate event", async () => {
     const util1 = new NetJSONGraphUtil();
     const util2 = new NetJSONGraphUtil();
     const self1 = {_popstateHandler: null};
@@ -881,6 +898,10 @@ describe("Test setupHashChangeHandler fragmentchange event", () => {
     self2._popstateHandler(popstateEvent);
     expect(util1.applyUrlFragmentState).toHaveBeenCalledWith(self1);
     expect(util2.applyUrlFragmentState).toHaveBeenCalledWith(self2);
+    // Both handlers ran — state restored, but dispatch queued as microtask
+    expect(dispatchSpy).not.toHaveBeenCalled();
+    // Flush microtasks
+    await Promise.resolve();
     expect(dispatchSpy).toHaveBeenCalledTimes(1);
     const event = dispatchSpy.mock.calls[0][0];
     expect(event.type).toBe("fragmentchange");


### PR DESCRIPTION
Add a custom fragmentchange event when URL fragments are updated in NetJSONGraph so external consumers can listen for URL changes without custom popstate or hashchange handlers. Added test coverage for this behavior.

Fixes #551

## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- [x] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [x] I have updated the documentation.

## Reference to Existing Issue

Closes #551.

## Description of Changes
- emits a new fragmentchange when id or nodeId param is added in url.
- use the fragmentchange in `netjsonmap-indoormap-overlay.html` instead of `popState`.
- make the `netjsonmap-indoormap-overlay.html` to add the indoor map id param on opening the floorplan overlay.
- Added new tests and fixed previous ones according to the new functionality. 

## Screenshot

[Screencast from 2026-06-01 22-24-30.webm](https://github.com/user-attachments/assets/209010a0-912f-422c-8305-c044ef2ebf72)
